### PR TITLE
Compile error due to wrong include

### DIFF
--- a/src/Multinomial.hpp
+++ b/src/Multinomial.hpp
@@ -1,7 +1,7 @@
 #ifndef KALLISTO_MULTINOMIAL_H
 #define KALLISTO_MULTINOMIAL_H
 
-#include <exception>
+#include <stdexcept>
 #include <random>
 
 class Multinomial {


### PR DESCRIPTION
Had a problem compiling on CentOS 6.5 with GCC 4.7.2 (via devtoolset-1.1).

$ make
[  8%] Building CXX object src/CMakeFiles/kallisto_core.dir/main.cpp.o
In file included from /usr/local/src/kallisto-0.42/src/Bootstrap.h:7:0,
                 from /usr/local/src/kallisto-0.42/src/main.cpp:27:
/usr/local/src/kallisto-0.42/src/Multinomial.hpp: In member function ‘std::vector<int> Multinomial::sample(int)’:
/usr/local/src/kallisto-0.42/src/Multinomial.hpp:35:23: error: ‘domain_error’ is not a member of ‘std’


Changing the include to stdexcept fixed it. 

(see http://stackoverflow.com/questions/25163105/stdexcept-vs-exception-headers-in-c)