### PR TITLE
Threaded bootstraps

### DIFF
--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -1,6 +1,6 @@
 #include "Bootstrap.h"
-#include "weights.h"
-#include "EMAlgorithm.h"
+// #include "weights.h"
+// #include "EMAlgorithm.h"
 
 EMAlgorithm Bootstrap::run_em(const EMAlgorithm& em_start) {
     auto counts = mult_.sample();
@@ -11,4 +11,55 @@ EMAlgorithm Bootstrap::run_em(const EMAlgorithm& em_start) {
     /* em.compute_rho(); */
 
     return em;
+}
+
+BootstrapThreadPool::BootstrapThreadPool(
+    size_t n_threads,
+    std::vector<size_t> seeds) :
+  n_threads_(n_threads),
+  seeds_(seeds),
+  n_complete_(0)
+{
+  for (size_t i = 0; i < n_threads_; ++i) {
+    threads_.push_back( std::thread(BootstrapWorker(*this, i)) );
+  }
+}
+
+BootstrapThreadPool::~BootstrapThreadPool() {
+  for (size_t i = 0; i < n_threads_; ++i) {
+    threads_[i].join();
+  }
+}
+
+void BootstrapWorker::operator() (){
+  while (true) {
+    size_t cur_seed;
+    size_t cur_id;
+
+    // acquire a seed
+    {
+      std::unique_lock<std::mutex> lock(pool_.seeds_mutex_);
+
+      if (pool_.seeds_.empty()) {
+        // no more bootstraps to perform, this thread is done
+        return;
+      }
+
+      cur_id = pool_.seeds_.size() - 1;
+      cur_seed = pool_.seeds_.back();
+      pool_.seeds_.pop_back();
+      std::cout << "cur seed from thread (" << thread_id_ << "): " <<
+        cur_seed <<  " id: " << cur_id << std::endl;
+    } // release lock
+
+
+    // write out data
+    {
+      std::unique_lock<std::mutex> lock(pool_.write_lock_);
+      ++pool_.n_complete_;
+      //std::cerr << "[bstrp] bootstraps complete: " << pool_.n_complete_ << "\r";
+
+    } // release write lock
+  }
+
 }

--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -63,8 +63,8 @@ void BootstrapWorker::operator() (){
       cur_id = pool_.seeds_.size() - 1;
       cur_seed = pool_.seeds_.back();
       pool_.seeds_.pop_back();
-      std::cout << "cur seed from thread (" << thread_id_ << "): " <<
-        cur_seed <<  " id: " << cur_id << std::endl;
+      // std::cout << "cur seed from thread (" << thread_id_ << "): " <<
+      //   cur_seed <<  " id: " << cur_id << std::endl;
     } // release lock
 
     Bootstrap bs(pool_.true_counts_,
@@ -79,9 +79,8 @@ void BootstrapWorker::operator() (){
     if (!pool_.opt_.plaintext) {
       std::unique_lock<std::mutex> lock(pool_.write_lock_);
       ++pool_.n_complete_;
-      //std::cerr << "[bstrp] bootstraps complete: " << pool_.n_complete_ << "\r";
+      std::cerr << "[bstrp] number of EM bootstraps complete: " << pool_.n_complete_ << "\r";
       pool_.writer_.write_bootstrap(res, cur_id);
-
       // release write lock
     } else {
       // can write out plaintext in parallel

--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -2,7 +2,7 @@
 // #include "weights.h"
 // #include "EMAlgorithm.h"
 
-EMAlgorithm Bootstrap::run_em(const EMAlgorithm& em_start) {
+EMAlgorithm Bootstrap::run_em() {
     auto counts = mult_.sample();
     EMAlgorithm em(counts, index_, tc_, mean_fl);
 
@@ -15,10 +15,25 @@ EMAlgorithm Bootstrap::run_em(const EMAlgorithm& em_start) {
 
 BootstrapThreadPool::BootstrapThreadPool(
     size_t n_threads,
-    std::vector<size_t> seeds) :
+    std::vector<size_t> seeds,
+    const std::vector<int>& true_counts,
+    const KmerIndex& index,
+    const MinCollector& tc,
+    const std::vector<double>& eff_lens,
+    double mean,
+    const ProgramOptions& p_opts,
+    H5Writer& h5writer
+    ) :
   n_threads_(n_threads),
   seeds_(seeds),
-  n_complete_(0)
+  n_complete_(0),
+  true_counts_(true_counts),
+  index_(index),
+  tc_(tc),
+  eff_lens_(eff_lens),
+  mean_fl_(mean),
+  opt_(p_opts),
+  writer_(h5writer)
 {
   for (size_t i = 0; i < n_threads_; ++i) {
     threads_.push_back( std::thread(BootstrapWorker(*this, i)) );
@@ -52,14 +67,28 @@ void BootstrapWorker::operator() (){
         cur_seed <<  " id: " << cur_id << std::endl;
     } // release lock
 
+    Bootstrap bs(pool_.true_counts_,
+        pool_.index_,
+        pool_.tc_,
+        pool_.eff_lens_,
+        pool_.mean_fl_,
+        cur_seed);
 
-    // write out data
-    {
+    auto res = bs.run_em();
+
+    if (!pool_.opt_.plaintext) {
       std::unique_lock<std::mutex> lock(pool_.write_lock_);
       ++pool_.n_complete_;
       //std::cerr << "[bstrp] bootstraps complete: " << pool_.n_complete_ << "\r";
+      pool_.writer_.write_bootstrap(res, cur_id);
 
-    } // release write lock
+      // release write lock
+    } else {
+      // can write out plaintext in parallel
+      plaintext_writer(pool_.opt_.output + "/bs_abundance_" +
+          std::to_string(cur_id) + ".txt",
+          pool_.index_.target_names_, res.alpha_,
+          pool_.eff_lens_, pool_.index_.trans_lens_);
+    }
   }
-
 }

--- a/src/Bootstrap.h
+++ b/src/Bootstrap.h
@@ -1,6 +1,9 @@
 #ifndef KALLISTO_BOOTSTRAP_H
 #define KALLISTO_BOOTSTRAP_H
 
+#include <mutex>
+#include <thread>
+
 #include "KmerIndex.h"
 #include "MinCollector.h"
 #include "weights.h"
@@ -27,12 +30,12 @@ public:
     seed_(seed),
     mult_(true_counts, seed_)
     {}
-  
+
   // EM Algorithm generates a sample from the Multinomial, then returns
   // an "EMAlgorithm" that has already run the EM as well as compute the
         // rho values
   EMAlgorithm run_em(const EMAlgorithm& em_start);
-  
+
 private:
   const KmerIndex& index_;
   const MinCollector& tc_;
@@ -40,6 +43,42 @@ private:
   double mean_fl;
   size_t seed_;
   Multinomial mult_;
+};
+
+class BootstrapThreadPool {
+  friend class BootstrapWorker;
+
+  public:
+    BootstrapThreadPool(
+        size_t n_threads,
+        std::vector<size_t> seeds
+        );
+    size_t num_threads() {return n_threads_;}
+
+    ~BootstrapThreadPool();
+  private:
+    std::vector<size_t> seeds_;
+    size_t n_threads_;
+
+    std::vector<std::thread> threads_;
+    std::mutex seeds_mutex_;
+    std::mutex write_lock_;
+
+    size_t n_complete_;
+};
+
+class BootstrapWorker {
+  public:
+    BootstrapWorker(BootstrapThreadPool& pool, size_t thread_id) :
+      pool_(pool),
+      thread_id_(thread_id)
+    {}
+
+  void operator()();
+
+  private:
+    BootstrapThreadPool& pool_;
+    size_t thread_id_;
 };
 
 #endif

--- a/src/Bootstrap.h
+++ b/src/Bootstrap.h
@@ -9,6 +9,7 @@
 #include "weights.h"
 #include "EMAlgorithm.h"
 #include "Multinomial.hpp"
+#include "H5Writer.h"
 
 class Bootstrap {
     // needs:
@@ -34,7 +35,7 @@ public:
   // EM Algorithm generates a sample from the Multinomial, then returns
   // an "EMAlgorithm" that has already run the EM as well as compute the
         // rho values
-  EMAlgorithm run_em(const EMAlgorithm& em_start);
+  EMAlgorithm run_em();
 
 private:
   const KmerIndex& index_;
@@ -51,8 +52,16 @@ class BootstrapThreadPool {
   public:
     BootstrapThreadPool(
         size_t n_threads,
-        std::vector<size_t> seeds
+        std::vector<size_t> seeds,
+        const std::vector<int>& true_counts,
+        const KmerIndex& index,
+        const MinCollector& tc,
+        const std::vector<double>& eff_lens,
+        double mean,
+        const ProgramOptions& p_opts,
+        H5Writer& h5writer
         );
+
     size_t num_threads() {return n_threads_;}
 
     ~BootstrapThreadPool();
@@ -65,6 +74,15 @@ class BootstrapThreadPool {
     std::mutex write_lock_;
 
     size_t n_complete_;
+
+    // things to run bootstrap
+    const std::vector<int> true_counts_;
+    const KmerIndex& index_;
+    const MinCollector& tc_;
+    const std::vector<double>& eff_lens_;
+    double mean_fl_;
+    const ProgramOptions& opt_;
+    H5Writer& writer_;
 };
 
 class BootstrapWorker {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -712,18 +712,18 @@ int main(int argc, char *argv[]) {
           std::cerr << "[quant] estimated average fragment length: " << mean_fl << std::endl;
         }
 
-        
+
         /*for (int i = 0; i < collection.bias3.size(); i++) {
           std::cout << i << "\t" << collection.bias3[i] << "\t" << collection.bias5[i] << "\n";
           }*/
-        
+
         //EMAlgorithm em(index.ecmap, collection.counts, index.target_names_, eff_lens, weights);
         EMAlgorithm em(collection.counts, index, collection, mean_fl);
         em.run(10000, 50, true, opt.bias);
 
         //update_eff_lens(mean_fl, collection, index, em.alpha_, eff_lens);
 
-        
+
         std::string call = argv_to_string(argc, argv);
 
         H5Writer writer;
@@ -756,12 +756,13 @@ int main(int argc, char *argv[]) {
           }
 
           if (opt.threads > 1) {
-            BootstrapThreadPool pool(3, seeds);
+            BootstrapThreadPool pool(opt.threads, seeds, collection.counts, index,
+                collection, em.eff_lens_, mean_fl, opt, writer);
           } else {
             for (auto b = 0; b < B; ++b) {
               Bootstrap bs(collection.counts, index, collection, em.eff_lens_, mean_fl, seeds[b]);
               cerr << "[bstrp] running EM for the bootstrap: " << b + 1<< "\r";
-              auto res = bs.run_em(em);
+              auto res = bs.run_em();
 
               if (!opt.plaintext) {
                 writer.write_bootstrap(res, b);
@@ -837,7 +838,7 @@ int main(int argc, char *argv[]) {
           for (auto b = 0; b < B; ++b) {
             Bootstrap bs(collection.counts, index, collection, em.eff_lens_, mean_fl, seeds[b]);
             std::cerr << "Running EM bootstrap: " << b + 1 << std::endl;
-            auto res = bs.run_em(em);
+            auto res = bs.run_em();
 
             if (!opt.plaintext) {
               writer.write_bootstrap(res, b);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -758,6 +758,16 @@ int main(int argc, char *argv[]) {
           }
 
           if (opt.threads > 1) {
+            auto n_threads = opt.threads;
+            if (opt.threads > opt.bootstrap) {
+              cerr
+                << "[~warn] number of threads (" << opt.threads <<
+                ") greater than number of bootstraps" << endl
+                << "[~warn] (cont'd) updating threads to number of bootstraps "
+                << opt.bootstrap << endl;
+              n_threads = opt.bootstrap;
+            }
+
             BootstrapThreadPool pool(opt.threads, seeds, collection.counts, index,
                 collection, em.eff_lens_, mean_fl, opt, writer);
           } else {
@@ -838,7 +848,16 @@ int main(int argc, char *argv[]) {
           }
 
           if (opt.threads > 1) {
-            BootstrapThreadPool pool(opt.threads, seeds, collection.counts, index,
+            auto n_threads = opt.threads;
+            if (opt.threads > opt.bootstrap) {
+              cerr << "[btstrp] Warning: number of threads (" << opt.threads <<
+                ") greater than number of bootstraps." << endl
+                << "[btstrp] (cont'd): Updating threads to number of bootstraps "
+                << opt.bootstrap << endl;
+              n_threads = opt.bootstrap;
+            }
+
+            BootstrapThreadPool pool(n_threads, seeds, collection.counts, index,
                 collection, em.eff_lens_, mean_fl, opt, writer);
           } else {
             for (auto b = 0; b < B; ++b) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -755,16 +755,20 @@ int main(int argc, char *argv[]) {
             seeds.push_back( rand() );
           }
 
-          for (auto b = 0; b < B; ++b) {
-            Bootstrap bs(collection.counts, index, collection, em.eff_lens_, mean_fl, seeds[b]);
-            cerr << "[bstrp] running EM for the bootstrap: " << b + 1<< "\r";
-            auto res = bs.run_em(em);
+          if (opt.threads > 1) {
+            BootstrapThreadPool pool(3, seeds);
+          } else {
+            for (auto b = 0; b < B; ++b) {
+              Bootstrap bs(collection.counts, index, collection, em.eff_lens_, mean_fl, seeds[b]);
+              cerr << "[bstrp] running EM for the bootstrap: " << b + 1<< "\r";
+              auto res = bs.run_em(em);
 
-            if (!opt.plaintext) {
-              writer.write_bootstrap(res, b);
-            } else {
-              plaintext_writer(opt.output + "/bs_abundance_" + std::to_string(b) + ".txt",
-                  em.target_names_, res.alpha_, em.eff_lens_, index.trans_lens_);
+              if (!opt.plaintext) {
+                writer.write_bootstrap(res, b);
+              } else {
+                plaintext_writer(opt.output + "/bs_abundance_" + std::to_string(b) + ".txt",
+                    em.target_names_, res.alpha_, em.eff_lens_, index.trans_lens_);
+              }
             }
           }
 


### PR DESCRIPTION
Threaded bootstraps

- Option `-t` now supplies the number of threads to use in bootstrap
- Only locks to get a seed and to write out to HDF5
  - Plaintext writing does not require locking since writing to different files
- Tested on Pall's "small" dataset and gives exactly the same result as serial bootstrap
  - If you don't supply a `-t` option, then it runs the "old" version of the code. We can refactor this to use the thread pools only, what do you guys think?