### PR TITLE
Effective length fix

### DIFF
--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -4,7 +4,7 @@
 
 EMAlgorithm Bootstrap::run_em() {
     auto counts = mult_.sample();
-    EMAlgorithm em(counts, index_, tc_, mean_fl);
+    EMAlgorithm em(counts, index_, tc_, mean_fl, mean_fls_);
 
     //em.set_start(em_start);
     em.run(10000, 50, false, false);
@@ -22,7 +22,8 @@ BootstrapThreadPool::BootstrapThreadPool(
     const std::vector<double>& eff_lens,
     double mean,
     const ProgramOptions& p_opts,
-    H5Writer& h5writer
+    H5Writer& h5writer,
+    const std::vector<double>& mean_fls
     ) :
   n_threads_(n_threads),
   seeds_(seeds),
@@ -33,7 +34,8 @@ BootstrapThreadPool::BootstrapThreadPool(
   eff_lens_(eff_lens),
   mean_fl_(mean),
   opt_(p_opts),
-  writer_(h5writer)
+  writer_(h5writer),
+  mean_fls_(mean_fls)
 {
   for (size_t i = 0; i < n_threads_; ++i) {
     threads_.push_back( std::thread(BootstrapWorker(*this, i)) );
@@ -72,7 +74,8 @@ void BootstrapWorker::operator() (){
         pool_.tc_,
         pool_.eff_lens_,
         pool_.mean_fl_,
-        cur_seed);
+        cur_seed,
+        pool_.mean_fls_);
 
     auto res = bs.run_em();
 

--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -4,7 +4,7 @@
 
 EMAlgorithm Bootstrap::run_em() {
     auto counts = mult_.sample();
-    EMAlgorithm em(counts, index_, tc_, mean_fl, mean_fls_);
+    EMAlgorithm em(counts, index_, tc_, mean_fls_);
 
     //em.set_start(em_start);
     em.run(10000, 50, false, false);
@@ -20,7 +20,6 @@ BootstrapThreadPool::BootstrapThreadPool(
     const KmerIndex& index,
     const MinCollector& tc,
     const std::vector<double>& eff_lens,
-    double mean,
     const ProgramOptions& p_opts,
     H5Writer& h5writer,
     const std::vector<double>& mean_fls
@@ -32,7 +31,6 @@ BootstrapThreadPool::BootstrapThreadPool(
   index_(index),
   tc_(tc),
   eff_lens_(eff_lens),
-  mean_fl_(mean),
   opt_(p_opts),
   writer_(h5writer),
   mean_fls_(mean_fls)
@@ -73,7 +71,6 @@ void BootstrapWorker::operator() (){
         pool_.index_,
         pool_.tc_,
         pool_.eff_lens_,
-        pool_.mean_fl_,
         cur_seed,
         pool_.mean_fls_);
 

--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -1,6 +1,4 @@
 #include "Bootstrap.h"
-// #include "weights.h"
-// #include "EMAlgorithm.h"
 
 EMAlgorithm Bootstrap::run_em() {
     auto counts = mult_.sample();

--- a/src/Bootstrap.h
+++ b/src/Bootstrap.h
@@ -23,13 +23,15 @@ public:
             const MinCollector& tc,
             const std::vector<double>& eff_lens,
             double mean,
-            size_t seed) :
+            size_t seed,
+            const std::vector<double>& mean_fls) :
     index_(index),
     tc_(tc),
     eff_lens_(eff_lens),
     mean_fl(mean),
     seed_(seed),
-    mult_(true_counts, seed_)
+    mult_(true_counts, seed_),
+    mean_fls_(mean_fls)
     {}
 
   // EM Algorithm generates a sample from the Multinomial, then returns
@@ -44,6 +46,7 @@ private:
   double mean_fl;
   size_t seed_;
   Multinomial mult_;
+  const std::vector<double>& mean_fls_;
 };
 
 class BootstrapThreadPool {
@@ -59,7 +62,8 @@ class BootstrapThreadPool {
         const std::vector<double>& eff_lens,
         double mean,
         const ProgramOptions& p_opts,
-        H5Writer& h5writer
+        H5Writer& h5writer,
+        const std::vector<double>& mean_fls
         );
 
     size_t num_threads() {return n_threads_;}
@@ -83,6 +87,7 @@ class BootstrapThreadPool {
     double mean_fl_;
     const ProgramOptions& opt_;
     H5Writer& writer_;
+    const std::vector<double>& mean_fls_;
 };
 
 class BootstrapWorker {

--- a/src/Bootstrap.h
+++ b/src/Bootstrap.h
@@ -22,13 +22,11 @@ public:
             const KmerIndex& index,
             const MinCollector& tc,
             const std::vector<double>& eff_lens,
-            double mean,
             size_t seed,
             const std::vector<double>& mean_fls) :
     index_(index),
     tc_(tc),
     eff_lens_(eff_lens),
-    mean_fl(mean),
     seed_(seed),
     mult_(true_counts, seed_),
     mean_fls_(mean_fls)
@@ -43,7 +41,6 @@ private:
   const KmerIndex& index_;
   const MinCollector& tc_;
   const std::vector<double>& eff_lens_;
-  double mean_fl;
   size_t seed_;
   Multinomial mult_;
   const std::vector<double>& mean_fls_;
@@ -60,7 +57,6 @@ class BootstrapThreadPool {
         const KmerIndex& index,
         const MinCollector& tc,
         const std::vector<double>& eff_lens,
-        double mean,
         const ProgramOptions& p_opts,
         H5Writer& h5writer,
         const std::vector<double>& mean_fls
@@ -84,7 +80,6 @@ class BootstrapThreadPool {
     const KmerIndex& index_;
     const MinCollector& tc_;
     const std::vector<double>& eff_lens_;
-    double mean_fl_;
     const ProgramOptions& opt_;
     H5Writer& writer_;
     const std::vector<double>& mean_fls_;

--- a/src/EMAlgorithm.h
+++ b/src/EMAlgorithm.h
@@ -26,13 +26,7 @@ struct EMAlgorithm {
   EMAlgorithm(const std::vector<int>& counts,
               const KmerIndex& index,
               const MinCollector& tc,
-              const std::vector<double>& all_means // TODO: get rid of 'mean' soon
-/*    const EcMap& ecmap,
-              const std::vector<int>& counts,
-              const std::vector<std::string>& target_names,
-
-              const WeightMap& wm*/) :
-    //idx_(idx),
+              const std::vector<double>& all_means) :
     index_(index),
     tc_(tc),
     num_trans_(index.target_names_.size()),
@@ -53,13 +47,13 @@ struct EMAlgorithm {
       } else {
         alpha_[i] = eff_lens_[i] / 1000.0;
       }
-      
+
     }
     assert(target_names_.size() == eff_lens_.size());
   }
-  
+
   ~EMAlgorithm() {}
-  
+
   void run(size_t n_iter = 10000, size_t min_rounds=50, bool verbose = true, bool recomputeEffLen = true) {
     std::vector<double> next_alpha(alpha_.size(), 0.0);
 
@@ -77,34 +71,25 @@ struct EMAlgorithm {
 
     int i;
     for (i = 0; i < n_iter; ++i) {
-      /*if (i % 50 == 0) {
-        std::cerr << ".";
-        std::cerr.flush();
-        if (i % 500 == 0 && i > 0) {
-          std::cerr << std::endl;
-        }
-        }*/
-
-
       if (recomputeEffLen && (i == min_rounds || i == min_rounds + 500)) {
         eff_lens_ = update_eff_lens(all_fl_means, tc_, index_, alpha_, eff_lens_);
         weight_map_ = calc_weights (tc_.counts, ecmap_, eff_lens_);
       }
 
-      
+
       //for (auto& ec_kv : ecmap_ ) {
       for (int ec = 0; ec < num_trans_; ec++) {
         next_alpha[ec] = counts_[ec];
       }
 
-      
+
       for (int ec = num_trans_; ec < ecmap_.size();  ec++) {
         denom = 0.0;
 
         if (counts_[ec] == 0) {
           continue;
         }
-        
+
         // first, compute the denominator: a normalizer
         // iterate over targets in EC map
         auto& wv = weight_map_[ec];
@@ -144,7 +129,7 @@ struct EMAlgorithm {
         if (next_alpha[ec] > alpha_change_limit && (std::fabs(next_alpha[ec] - alpha_[ec]) / next_alpha[ec]) > alpha_change) {
           chcount++;
         }
-        
+
         //if (stopEM && next_alpha[ec] >= alpha_limit) {
 
           /* double reldiff = abs(next_alpha[ec]-alpha_[ec]) / next_alpha[ec];
@@ -290,7 +275,7 @@ struct EMAlgorithm {
     }
 
     std::cout << sum_big << " " << count_big << " " << n << std::endl;
- 
+
     std::copy(em_start.alpha_before_zeroes_.begin(), em_start.alpha_before_zeroes_.end(),
         alpha_.begin());
   }

--- a/src/EMAlgorithm.h
+++ b/src/EMAlgorithm.h
@@ -89,7 +89,7 @@ struct EMAlgorithm {
 
 
       if (recomputeEffLen && (i == min_rounds || i == min_rounds + 500)) {
-        eff_lens_ = update_eff_lens(mean_fl, tc_, index_, alpha_, eff_lens_);
+        eff_lens_ = update_eff_lens(mean_fl, tc_, index_, alpha_, eff_lens_, all_fl_means);
         weight_map_ = calc_weights (tc_.counts, ecmap_, eff_lens_);
       }
 

--- a/src/EMAlgorithm.h
+++ b/src/EMAlgorithm.h
@@ -26,7 +26,6 @@ struct EMAlgorithm {
   EMAlgorithm(const std::vector<int>& counts,
               const KmerIndex& index,
               const MinCollector& tc,
-              double mean,
               const std::vector<double>& all_means // TODO: get rid of 'mean' soon
 /*    const EcMap& ecmap,
               const std::vector<int>& counts,
@@ -43,7 +42,6 @@ struct EMAlgorithm {
     alpha_(num_trans_, 1.0/num_trans_), // uniform distribution over targets
     rho_(num_trans_, 0.0),
     rho_set_(false),
-    mean_fl(mean),
     all_fl_means(all_means)
   {
     assert(all_fl_means.size() == index_.target_lens_.size());
@@ -311,7 +309,6 @@ struct EMAlgorithm {
   std::vector<double> alpha_before_zeroes_;
   std::vector<double> rho_;
   bool rho_set_;
-  double mean_fl;
 };
 
 

--- a/src/EMAlgorithm.h
+++ b/src/EMAlgorithm.h
@@ -89,7 +89,7 @@ struct EMAlgorithm {
 
 
       if (recomputeEffLen && (i == min_rounds || i == min_rounds + 500)) {
-        eff_lens_ = update_eff_lens(mean_fl, tc_, index_, alpha_, eff_lens_, all_fl_means);
+        eff_lens_ = update_eff_lens(all_fl_means, tc_, index_, alpha_, eff_lens_);
         weight_map_ = calc_weights (tc_.counts, ecmap_, eff_lens_);
       }
 

--- a/src/EMAlgorithm.h
+++ b/src/EMAlgorithm.h
@@ -26,7 +26,8 @@ struct EMAlgorithm {
   EMAlgorithm(const std::vector<int>& counts,
               const KmerIndex& index,
               const MinCollector& tc,
-              double mean
+              double mean,
+              const std::vector<double>& all_means // TODO: get rid of 'mean' soon
 /*    const EcMap& ecmap,
               const std::vector<int>& counts,
               const std::vector<std::string>& target_names,
@@ -42,11 +43,13 @@ struct EMAlgorithm {
     alpha_(num_trans_, 1.0/num_trans_), // uniform distribution over targets
     rho_(num_trans_, 0.0),
     rho_set_(false),
-    mean_fl(mean)
+    mean_fl(mean),
+    all_fl_means(all_means)
   {
-    eff_lens_ = calc_eff_lens(index_.target_lens_, mean_fl);
+    assert(all_fl_means.size() == index_.target_lens_.size());
+    eff_lens_ = calc_eff_lens(index_.target_lens_, all_fl_means);
     weight_map_ = calc_weights (tc_.counts, ecmap_, eff_lens_);
-    for (auto i = 0; i < alpha_.size(); i++) {
+    for (size_t i = 0; i < alpha_.size(); i++) {
       if (counts_[i] > 0) {
         alpha_[i] = counts_[i];
       } else {
@@ -301,6 +304,7 @@ struct EMAlgorithm {
   const EcMap& ecmap_;
   const std::vector<int>& counts_;
   const std::vector<std::string>& target_names_;
+  const std::vector<double>& all_fl_means;
   std::vector<double> eff_lens_;
   WeightMap weight_map_;
   std::vector<double> alpha_;

--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -212,7 +212,7 @@ double MinCollector::get_mean_frag_len() const {
   if (has_mean_fl) {
     return mean_fl;
   }
-  
+
   auto total_counts = 0;
   double total_mass = 0.0;
 
@@ -225,9 +225,9 @@ double MinCollector::get_mean_frag_len() const {
     std::cerr << "Error: could not determine mean fragment length from paired end reads, no pairs mapped to a unique transcript." << std::endl
               << "       Run kallisto quant again with a pre-specified fragment length (option -l)." << std::endl;
     exit(1);
-    
+
   }
-  
+
   // cache the value
   const_cast<double&>(mean_fl) = total_mass / static_cast<double>(total_counts);
   const_cast<bool&>(has_mean_fl) = true;
@@ -251,6 +251,8 @@ void MinCollector::get_mean_frag_lens_trunc() const {
     // std::cerr << "--- " << i << '\t' << mean_fl_trunc[i] << std::endl;
   }
 
+  const_cast<bool&>(has_mean_fl_trunc) = true;
+
   std::cerr << "[quant] estimated average fragment length: " <<
     mean_fl_trunc[MAX_FRAG_LEN - 1] << std::endl;
 }
@@ -266,7 +268,7 @@ int hexamerToInt(const char *s, bool revcomp) {
       case 'G': hex += 2; break;
       case 'T': hex += 3; break;
       default: return -1;
-      }    
+      }
     }
   } else {
     for (int i = 0; i < 6; i++) {
@@ -276,7 +278,7 @@ int hexamerToInt(const char *s, bool revcomp) {
       case 'G': hex += 1 << (2*i); break;
       case 'T': break;
       default: return -1;
-      }    
+      }
     }
   }
   return hex;
@@ -285,13 +287,13 @@ int hexamerToInt(const char *s, bool revcomp) {
 bool MinCollector::countBias(const char *s1, const char *s2, const std::vector<std::pair<KmerEntry,int>> v1, const std::vector<std::pair<KmerEntry,int>> v2, bool paired) {
 
   const int pre = 2, post = 4;
-  
+
   if (v1.empty() || (paired && v2.empty())) {
     return false;
   }
 
 
-  
+
   auto getPreSeq = [&](const char *s, Kmer km, bool fw, bool csense,  KmerEntry val, int p) -> int {
     if (s==0) {
       return -1;
@@ -299,7 +301,7 @@ bool MinCollector::countBias(const char *s1, const char *s2, const std::vector<s
     if ((csense && val.getPos() - p >= pre) || (!csense && (val.contig_length - 1 - val.getPos() - p) >= pre )) {
       const Contig &c = index.dbGraph.contigs[val.contig];
       bool sense = c.transcripts[0].sense;
-      
+
       int hex = -1;
       //std::cout << "  " << s << "\n";
       if (csense) {
@@ -325,7 +327,7 @@ bool MinCollector::countBias(const char *s1, const char *s2, const std::vector<s
       p1 = x.second;
     }
   }
-  
+
   Kmer km1 = Kmer((s1+p1));
   bool fw1 = (km1==km1.rep());
   bool csense1 = (fw1 == val1.isFw()); // is this in the direction of the contig?
@@ -344,15 +346,15 @@ bool MinCollector::countBias(const char *s1, const char *s2, const std::vector<s
         p2 = x.second;
       }
     }
-    
+
     Kmer km2 = Kmer((s2+p2));
     bool fw2 = (km2==km2.rep());
     bool csense2 = (fw2 == val2.isFw()); // is this in the direction of the contig?
-    
+
     hex3 = getPreSeq(s2, km2, fw2, csense2, val2, p2);
   }
   */
-  
+
   if (hex5 >=0) { // && (!paired || hex3 >= 0)) {
     bias5[hex5]++;
     //bias3[hex3]++;

--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -21,6 +21,15 @@ std::vector<int> intersect(const std::vector<int>& x, const std::vector<int>& y)
   return v;
 }
 
+void MinCollector::init_mean(double mean) {
+  for (size_t i = 0 ; i < mean_fl_trunc.size(); ++i) {
+    mean_fl_trunc[i] = mean;
+  }
+  mean_fl = mean;
+
+  has_mean_fl = true;
+  has_mean_fl_trunc = true;
+}
 
 int MinCollector::collect(std::vector<std::pair<KmerEntry,int>>& v1,
                           std::vector<std::pair<KmerEntry,int>>& v2, bool nonpaired) {

--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -248,8 +248,11 @@ void MinCollector::get_mean_frag_lens_trunc() const {
     if (counts[i] > 0) {
       const_cast<double&>(mean_fl_trunc[i]) = mass[i] / static_cast<double>(counts[i]);
     }
-    std::cerr << "--- " << i << '\t' << mean_fl_trunc[i] << std::endl;
+    // std::cerr << "--- " << i << '\t' << mean_fl_trunc[i] << std::endl;
   }
+
+  std::cerr << "[quant] estimated average fragment length: " <<
+    mean_fl_trunc[MAX_FRAG_LEN - 1] << std::endl;
 }
 
 int hexamerToInt(const char *s, bool revcomp) {

--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -223,6 +223,23 @@ double MinCollector::get_mean_frag_len() const {
   return mean_fl;
 }
 
+void MinCollector::get_mean_frag_lens_trunc() const {
+
+  std::vector<int> counts(MAX_FRAG_LEN, 0);
+  std::vector<double> mass(MAX_FRAG_LEN, 0.0);
+
+  counts[0] = flens[0];
+
+  for (size_t i = 1; i < MAX_FRAG_LEN; ++i) {
+    // mass and counts keep track of the mass/counts up to and including index i
+    mass[i] = static_cast<double>( flens[i] * i) + mass[i-1];
+    counts[i] = flens[i] + counts[i-1];
+    if (counts[i] > 0) {
+      const_cast<double&>(mean_fl_trunc[i]) = mass[i] / static_cast<double>(counts[i]);
+    }
+    std::cerr << "--- " << i << '\t' << mean_fl_trunc[i] << std::endl;
+  }
+}
 
 int hexamerToInt(const char *s, bool revcomp) {
   int hex = 0;

--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -21,11 +21,13 @@ std::vector<int> intersect(const std::vector<int>& x, const std::vector<int>& y)
   return v;
 }
 
-void MinCollector::init_mean(double mean) {
-  for (size_t i = 0 ; i < mean_fl_trunc.size(); ++i) {
-    mean_fl_trunc[i] = mean;
-  }
-  mean_fl = mean;
+void MinCollector::init_mean_fl_trunc(double mean, double sd) {
+  auto tmp_trunc_fl = trunc_gaussian_fld(0, MAX_FRAG_LEN, mean, sd);
+  assert( tmp_trunc_fl.size() == mean_fl_trunc.size() );
+
+  std::copy( tmp_trunc_fl.begin(), tmp_trunc_fl.end(), mean_fl_trunc.begin() );
+
+  mean_fl = mean_fl_trunc[ MAX_FRAG_LEN - 1 ];
 
   has_mean_fl = true;
   has_mean_fl_trunc = true;

--- a/src/MinCollector.h
+++ b/src/MinCollector.h
@@ -58,6 +58,9 @@ struct MinCollector {
 
   void get_mean_frag_lens_trunc() const;
 
+  // this function is a bit of a hack. should only be used with SE data
+  void init_mean(double mean);
+
   /* double eff_len(int len) const; */
 
   KmerIndex& index;

--- a/src/MinCollector.h
+++ b/src/MinCollector.h
@@ -10,7 +10,7 @@
 
 #include "KmerIndex.h"
 
-const size_t MAX_FRAG_LEN = 1000;
+const int MAX_FRAG_LEN = 1000;
 
 struct MinCollector {
 
@@ -27,6 +27,7 @@ struct MinCollector {
       has_mean_fl(false),
       mean_fl_trunc(MAX_FRAG_LEN, 0.0),
       has_mean_fl_trunc(false)
+      // eff_len_cache(MAX_FRAG_LEN, 0.0)
        {}
 
   int collect(std::vector<std::pair<KmerEntry,int>>& v1,
@@ -57,6 +58,7 @@ struct MinCollector {
 
   void get_mean_frag_lens_trunc() const;
 
+  /* double eff_len(int len) const; */
 
   KmerIndex& index;
   std::vector<int> counts;
@@ -70,6 +72,8 @@ struct MinCollector {
 
   std::vector<double> mean_fl_trunc;
   bool has_mean_fl_trunc;
+
+  // std::vector<double> eff_len_cache;
 };
 
 std::vector<int> intersect(const std::vector<int>& x, const std::vector<int>& y);

--- a/src/MinCollector.h
+++ b/src/MinCollector.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 #include "KmerIndex.h"
+#include "weights.h"
 
 const int MAX_FRAG_LEN = 1000;
 
@@ -59,7 +60,7 @@ struct MinCollector {
   void get_mean_frag_lens_trunc() const;
 
   // this function is a bit of a hack. should only be used with SE data
-  void init_mean(double mean);
+  void init_mean_fl_trunc(double mean, double sd);
 
   /* double eff_len(int len) const; */
 

--- a/src/MinCollector.h
+++ b/src/MinCollector.h
@@ -45,7 +45,6 @@ struct MinCollector {
 
   std::vector<int> intersectECs(std::vector<std::pair<KmerEntry,int>>& v) const;
 
-
   void write(std::ostream& o) {
     for (int id = 0; id < counts.size(); id++) {
       o << id << "\t" << counts[id] << "\n";
@@ -55,14 +54,14 @@ struct MinCollector {
 
   bool countBias(const char *s1, const char *s2, const std::vector<std::pair<KmerEntry,int>> v1, const std::vector<std::pair<KmerEntry,int>> v2, bool paired);
 
+  // DEPRECATED
   double get_mean_frag_len() const;
 
+  // compute the conditional mean of each target given the FLD
   void get_mean_frag_lens_trunc() const;
 
-  // this function is a bit of a hack. should only be used with SE data
+  // this function should only be used for SE data
   void init_mean_fl_trunc(double mean, double sd);
-
-  /* double eff_len(int len) const; */
 
   KmerIndex& index;
   std::vector<int> counts;
@@ -76,14 +75,9 @@ struct MinCollector {
 
   std::vector<double> mean_fl_trunc;
   bool has_mean_fl_trunc;
-
-  // std::vector<double> eff_len_cache;
 };
 
 std::vector<int> intersect(const std::vector<int>& x, const std::vector<int>& y);
-
-// compute the mean fragment length from a min_collector
-
 
 int hexamerToInt(const char *s, bool revcomp);
 

--- a/src/MinCollector.h
+++ b/src/MinCollector.h
@@ -29,7 +29,12 @@ struct MinCollector {
       mean_fl_trunc(MAX_FRAG_LEN, 0.0),
       has_mean_fl_trunc(false)
       // eff_len_cache(MAX_FRAG_LEN, 0.0)
-       {}
+       {
+         if (opt.fld != 0.0) {
+           mean_fl = opt.fld;
+           has_mean_fl = true;
+         }
+       }
 
   int collect(std::vector<std::pair<KmerEntry,int>>& v1,
               std::vector<std::pair<KmerEntry,int>>& v2,

--- a/src/MinCollector.h
+++ b/src/MinCollector.h
@@ -10,10 +10,24 @@
 
 #include "KmerIndex.h"
 
+const size_t MAX_FRAG_LEN = 1000;
 
 struct MinCollector {
 
-  MinCollector(KmerIndex& ind, const ProgramOptions& opt) : index(ind), counts(index.ecmap.size(), 0), flens(1000), bias3(4096), bias5(4096), min_range(opt.min_range), k(opt.k), mean_fl(0.0), has_mean_fl(false) {}
+  MinCollector(KmerIndex& ind, const ProgramOptions& opt)
+    :
+      index(ind),
+      counts(index.ecmap.size(), 0),
+      flens(MAX_FRAG_LEN),
+      bias3(4096),
+      bias5(4096),
+      min_range(opt.min_range),
+      k(opt.k),
+      mean_fl(0.0),
+      has_mean_fl(false),
+      mean_fl_trunc(MAX_FRAG_LEN, 0.0),
+      has_mean_fl_trunc(false)
+       {}
 
   int collect(std::vector<std::pair<KmerEntry,int>>& v1,
               std::vector<std::pair<KmerEntry,int>>& v2,
@@ -40,16 +54,22 @@ struct MinCollector {
   bool countBias(const char *s1, const char *s2, const std::vector<std::pair<KmerEntry,int>> v1, const std::vector<std::pair<KmerEntry,int>> v2, bool paired);
 
   double get_mean_frag_len() const;
-  
-  
+
+  void get_mean_frag_lens_trunc() const;
+
+
   KmerIndex& index;
   std::vector<int> counts;
   std::vector<int> flens;
   std::vector<int> bias3, bias5;
   int min_range;
   int k;
+
   double mean_fl;
   bool has_mean_fl;
+
+  std::vector<double> mean_fl_trunc;
+  bool has_mean_fl_trunc;
 };
 
 std::vector<int> intersect(const std::vector<int>& x, const std::vector<int>& y);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -717,16 +717,21 @@ int main(int argc, char *argv[]) {
         auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
         if (opt.fld == 0.0) {
           std::cerr << "[quant] estimated average fragment length: " << mean_fl << std::endl;
+          // TODO: eventually remove the 'mean fl' calculation above
+          // I think the way to get around this for SE reads is simply to dump
+          // the inputted mean into every position in the vector to reduce the
+          // extra logic everywhere. -HP
+          collection.get_mean_frag_lens_trunc();
         }
 
-        collection.get_mean_frag_lens_trunc();
 
         /*for (int i = 0; i < collection.bias3.size(); i++) {
           std::cout << i << "\t" << collection.bias3[i] << "\t" << collection.bias5[i] << "\n";
           }*/
 
         //EMAlgorithm em(index.ecmap, collection.counts, index.target_names_, eff_lens, weights);
-        EMAlgorithm em(collection.counts, index, collection, mean_fl);
+        auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);
+        EMAlgorithm em(collection.counts, index, collection, mean_fl, fl_means);
         em.run(10000, 50, true, opt.bias);
 
         //update_eff_lens(mean_fl, collection, index, em.alpha_, eff_lens);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -715,6 +715,7 @@ int main(int argc, char *argv[]) {
 
         // if mean FL not provided, estimate
         auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
+        auto sd_fl = 80.0;
         if (opt.fld == 0.0) {
           std::cerr << "[quant] estimated average fragment length: " << mean_fl << std::endl;
           // TODO: eventually remove the 'mean fl' calculation above
@@ -723,7 +724,11 @@ int main(int argc, char *argv[]) {
           // extra logic everywhere. -HP
           collection.get_mean_frag_lens_trunc();
         } else {
-          collection.init_mean( mean_fl );
+          collection.init_mean_fl_trunc( mean_fl, sd_fl );
+          cout << collection.mean_fl_trunc.size() << endl;
+          for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
+            cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
+          }
         }
 
         auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);
@@ -824,6 +829,7 @@ int main(int argc, char *argv[]) {
 
         // if mean FL not provided, estimate
         auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
+        auto sd_fl = 80.0;
         if (opt.fld == 0.0) {
           std::cerr << "[quant] estimated average fragment length: " << mean_fl << std::endl;
           // TODO: eventually remove the 'mean fl' calculation above
@@ -832,7 +838,11 @@ int main(int argc, char *argv[]) {
           // extra logic everywhere. -HP
           collection.get_mean_frag_lens_trunc();
         } else {
-          collection.init_mean( mean_fl );
+          collection.init_mean_fl_trunc( mean_fl, sd_fl );
+          cout << collection.mean_fl_trunc.size() << endl;
+          for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
+            cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
+          }
         }
 
         auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -719,6 +719,7 @@ int main(int argc, char *argv[]) {
           std::cerr << "[quant] estimated average fragment length: " << mean_fl << std::endl;
         }
 
+        collection.get_mean_frag_lens_trunc();
 
         /*for (int i = 0; i < collection.bias3.size(); i++) {
           std::cout << i << "\t" << collection.bias3[i] << "\t" << collection.bias5[i] << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -645,7 +645,7 @@ int main(int argc, char *argv[]) {
   std::cout.sync_with_stdio(false);
   setvbuf(stdout, NULL, _IOFBF, 1048576);
 
-  
+
   if (argc < 2) {
     usage();
     exit(1);
@@ -716,15 +716,13 @@ int main(int argc, char *argv[]) {
         // if mean FL not provided, estimate
         if (opt.fld == 0.0) {
           collection.get_mean_frag_lens_trunc();
-
         } else {
           auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
           auto sd_fl = 80.0;
           collection.init_mean_fl_trunc( mean_fl, sd_fl );
-          cout << collection.mean_fl_trunc.size() << endl;
-          for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
-            cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
-          }
+          // for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
+          //   cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
+          // }
         }
 
         auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);
@@ -733,12 +731,8 @@ int main(int argc, char *argv[]) {
           std::cout << i << "\t" << collection.bias3[i] << "\t" << collection.bias5[i] << "\n";
           }*/
 
-        //EMAlgorithm em(index.ecmap, collection.counts, index.target_names_, eff_lens, weights);
         EMAlgorithm em(collection.counts, index, collection, fl_means);
         em.run(10000, 50, true, opt.bias);
-
-        //update_eff_lens(mean_fl, collection, index, em.alpha_, eff_lens);
-
 
         std::string call = argv_to_string(argc, argv);
 
@@ -768,8 +762,6 @@ int main(int argc, char *argv[]) {
 
           std::vector<size_t> seeds;
           for (auto s = 0; s < B; ++s) {
-            // TODO: check whether or not there are collisions. they happen
-            // with tiny probability... but technically still can happen - HP
             seeds.push_back( rand() );
           }
 
@@ -837,8 +829,6 @@ int main(int argc, char *argv[]) {
 
         auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);
 
-
-        //EMAlgorithm em(index.ecmap, collection.counts, index.target_names_, eff_lens, weights);
         EMAlgorithm em(collection.counts, index, collection, fl_means);
         em.run(10000, 50, true, opt.bias);
 

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -123,7 +123,7 @@ std::vector<double> update_eff_lens(double mean,
     if (alpha[i] < 1e-8) {
       continue;
     }
-    
+
     double contrib = 0.5*alpha[i]/eff_lens[i];
     int seqlen = index.target_seqs_[i].size();
     const char* cs = index.target_seqs_[i].c_str();
@@ -179,7 +179,7 @@ std::vector<double> update_eff_lens(double mean,
       efflen *= 0.5*biasAlphaNorm/biasDataNorm;
     }
 
-    
+
     if (efflen > mean) {
       //efflen *= ((seqlen-mean) / ((double) (seqlen-mean-6));
       biaslens[i] = efflen;
@@ -188,7 +188,7 @@ std::vector<double> update_eff_lens(double mean,
     }
     //std::cout << index.target_names_[i] << "\t" << eff_lens[i] << "\t" << biaslens[i] << "\t" << efflen << "\n";
   }
-  
+
 
 
   return biaslens;
@@ -223,4 +223,29 @@ WeightMap calc_weights(
 
 
   return weights;
+}
+
+std::vector<double> trunc_gaussian_fld(int start, int stop, double mean,
+    double sd) {
+  size_t n = stop - start;
+  std::vector<double> mean_fl(n, 0.0);
+
+  double total_mass = 0.0;
+  double total_density = 0.0;
+
+  for (size_t i = 0; i < n + 1; ++i) {
+    double x = static_cast<double>(start + i);
+    x = (x - mean) / sd;
+    // XXX: this isn't normalized, but it doesn't matter since it gets
+    // normalized below
+    double cur_density = std::exp( - 0.5 * x * x ) / sd;
+
+    total_mass += cur_density * i;
+    total_density += cur_density;
+    if (total_mass > 0) {
+      mean_fl[i] = total_mass / total_density;
+    }
+  }
+
+  return mean_fl;
 }

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -57,6 +57,22 @@ std::vector<double> calc_eff_lens(const std::vector<int>& lengths,
   std::vector<double> eff_lens;
   eff_lens.reserve( lengths.size() );
 
+  assert( lengths.size() == means.size() );
+
+  // Sir Too $hort comin' straight from Oakland
+  auto n_too_short = 0;
+
+  for (size_t i = 0; i < lengths.size(); ++i) {
+    double cur_len_dbl = static_cast<double>(lengths[i]);
+    double cur_eff_len = cur_len_dbl - means[i] + 1;
+    if (cur_eff_len < 1.0) {
+      cur_eff_len = cur_len_dbl;
+      ++n_too_short;
+    }
+    eff_lens.push_back( cur_eff_len );
+  }
+
+  return eff_lens;
 }
 
 inline int update_hexamer(int hex, char c, bool revcomp) {
@@ -78,8 +94,13 @@ inline int update_hexamer(int hex, char c, bool revcomp) {
   return hex;
 }
 
-std::vector<double> update_eff_lens(double mean, const MinCollector& tc,  const KmerIndex &index, const std::vector<double> alpha, const std::vector<double> eff_lens) {
+std::vector<double> update_eff_lens(double mean,
+    const MinCollector& tc,
+    const KmerIndex &index,
+    const std::vector<double> alpha,
+    const std::vector<double> eff_lens) {
   // Pall: is there a reason 'eff_lens' isn't passed by ref?
+  // TODO: need to go through this and replace 'mean' with the vector of means
 
   double biasDataNorm = 0.0;
   double biasAlphaNorm = 0.0;
@@ -94,6 +115,8 @@ std::vector<double> update_eff_lens(double mean, const MinCollector& tc,  const 
 
   for (int i = 0; i < index.num_trans; i++) {
     if (index.target_lens_[i] < mean) {
+      // if we replace 'mean' with the proposed vector, then this case
+      // shouldn't happen
       continue;
     }
 

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -100,7 +100,6 @@ std::vector<double> update_eff_lens(double mean,
     const std::vector<double>& alpha,
     const std::vector<double>& eff_lens,
     const std::vector<double>& means) {
-  // Pall: is there a reason 'eff_lens' isn't passed by ref?
   // TODO: need to go through this and replace 'mean' with the vector of means
 
   double biasDataNorm = 0.0;
@@ -115,9 +114,9 @@ std::vector<double> update_eff_lens(double mean,
   index.loadTranscriptSequences();
 
   for (int i = 0; i < index.num_trans; i++) {
-    if (index.target_lens_[i] < mean) {
-      // if we replace 'mean' with the proposed vector, then this case
-      // shouldn't happen
+    if (index.target_lens_[i] < means[i]) {
+      // this should never happen.. but I'll sleep better at night with this
+      // condition -HP
       continue;
     }
 
@@ -154,8 +153,7 @@ std::vector<double> update_eff_lens(double mean,
 
   for (int i = 0; i < index.num_trans; i++) {
     double efflen = 0.0;
-    // i think we can safely remove the 'mean' ineq here - HP
-    if (index.target_lens_[i] >= mean && alpha[i] >= 1e-8) {
+    if (index.target_lens_[i] >= means[i] && alpha[i] >= 1e-8) {
 
       int seqlen = index.target_seqs_[i].size();
       const char* cs = index.target_seqs_[i].c_str();

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -1,5 +1,29 @@
 #include "weights.h"
+
 #include <cmath>
+
+std::vector<double> get_frag_len_means(const std::vector<int>& lengths,
+    const std::vector<double>& mean_frag_len_trunc) {
+
+  std::vector<double> frag_len_means;
+  frag_len_means.reserve( lengths.size() );
+
+  // we'll just assume we don't see any fragments longer or equal to
+  // MAX_FRAG_LEN
+  double marginal_mean = mean_frag_len_trunc[MAX_FRAG_LEN - 1];
+
+  for (size_t i = 0; i < lengths.size(); ++i) {
+
+    if (lengths[i] >= MAX_FRAG_LEN) {
+      frag_len_means[i] = marginal_mean;
+    } else {
+      frag_len_means[i] = mean_frag_len_trunc[i];
+    }
+
+  }
+
+  return frag_len_means;
+}
 
 std::vector<double> calc_eff_lens(const std::vector<int>& lengths, double mean)
 {
@@ -28,6 +52,13 @@ std::vector<double> calc_eff_lens(const std::vector<int>& lengths, double mean)
   return eff_lens;
 }
 
+std::vector<double> calc_eff_lens(const std::vector<int>& lengths,
+    const std::vector<double>& means) {
+  std::vector<double> eff_lens;
+  eff_lens.reserve( lengths.size() );
+
+}
+
 inline int update_hexamer(int hex, char c, bool revcomp) {
   if (!revcomp) {
     hex = ((hex & 0x3FF) << 2);
@@ -48,6 +79,7 @@ inline int update_hexamer(int hex, char c, bool revcomp) {
 }
 
 std::vector<double> update_eff_lens(double mean, const MinCollector& tc,  const KmerIndex &index, const std::vector<double> alpha, const std::vector<double> eff_lens) {
+  // Pall: is there a reason 'eff_lens' isn't passed by ref?
 
   double biasDataNorm = 0.0;
   double biasAlphaNorm = 0.0;

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -15,9 +15,9 @@ std::vector<double> get_frag_len_means(const std::vector<int>& lengths,
   for (size_t i = 0; i < lengths.size(); ++i) {
 
     if (lengths[i] >= MAX_FRAG_LEN) {
-      frag_len_means[i] = marginal_mean;
+      frag_len_means.push_back(marginal_mean);
     } else {
-      frag_len_means[i] = mean_frag_len_trunc[i];
+      frag_len_means.push_back(mean_frag_len_trunc[ lengths[i] ]);
     }
 
   }

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -104,7 +104,6 @@ std::vector<double> update_eff_lens(
     const std::vector<double>& alpha,
     const std::vector<double>& eff_lens
     ) {
-  // TODO: need to go through this and replace 'mean' with the vector of means
 
   double biasDataNorm = 0.0;
   double biasAlphaNorm = 0.0;

--- a/src/weights.h
+++ b/src/weights.h
@@ -16,8 +16,12 @@ std::vector<double> get_frag_len_means(const std::vector<int>& lengths,
     const std::vector<double>& mean_frag_len_trunc);
 
 std::vector<double> calc_eff_lens(const std::vector<int>& lengths, double mean);
+
+// @param lengths the lengths of all the targets
+// @param means the mean frag len of every transcript
 std::vector<double> calc_eff_lens(const std::vector<int>& lengths,
     const std::vector<double>& means);
+
 std::vector<double> update_eff_lens(double mean, const MinCollector& tc, const KmerIndex &index, const std::vector<double> alpha, const std::vector<double> eff_lens);
 
 

--- a/src/weights.h
+++ b/src/weights.h
@@ -9,7 +9,15 @@
 
 using WeightMap = std::vector<std::vector<double>>;
 
+// this function takes the 'mean_fl_trunc' from MinCollector and simply gives
+// you back a 'mean fragment length' for every single transcript. this avoids
+// you having to check the length every single time
+std::vector<double> get_frag_len_means(const std::vector<int>& lengths,
+    const std::vector<double>& mean_frag_len_trunc);
+
 std::vector<double> calc_eff_lens(const std::vector<int>& lengths, double mean);
+std::vector<double> calc_eff_lens(const std::vector<int>& lengths,
+    const std::vector<double>& means);
 std::vector<double> update_eff_lens(double mean, const MinCollector& tc, const KmerIndex &index, const std::vector<double> alpha, const std::vector<double> eff_lens);
 
 

--- a/src/weights.h
+++ b/src/weights.h
@@ -3,9 +3,12 @@
 
 #include "KmerIndex.h"
 #include "MinCollector.h"
+#include <cmath>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+struct MinCollector;
 
 using WeightMap = std::vector<std::vector<double>>;
 
@@ -29,5 +32,16 @@ WeightMap calc_weights(
   const std::vector<int>& counts,
   const EcMap& ecmap,
   const std::vector<double>& eff_lens);
+
+
+// truncated gaussian fragment length distribution
+//
+// use this for single-end reads since we don't have an empirical distribution
+//
+// start: inclusive
+// stop: exclusive
+// let's pretend all the input is sane
+std::vector<double> trunc_gaussian_fld(int start, int stop, double mean,
+    double sd);
 
 #endif // KALLISTO_WEIGHTS_H

--- a/src/weights.h
+++ b/src/weights.h
@@ -25,7 +25,9 @@ std::vector<double> calc_eff_lens(const std::vector<int>& lengths, double mean);
 std::vector<double> calc_eff_lens(const std::vector<int>& lengths,
     const std::vector<double>& means);
 
-std::vector<double> update_eff_lens(double mean, const MinCollector& tc, const KmerIndex &index, const std::vector<double> alpha, const std::vector<double> eff_lens);
+std::vector<double> update_eff_lens(double mean, const MinCollector& tc,
+    const KmerIndex &index, const std::vector<double>& alpha,
+    const std::vector<double>& eff_lens, const std::vector<double>& means);
 
 
 WeightMap calc_weights(

--- a/src/weights.h
+++ b/src/weights.h
@@ -18,6 +18,7 @@ using WeightMap = std::vector<std::vector<double>>;
 std::vector<double> get_frag_len_means(const std::vector<int>& lengths,
     const std::vector<double>& mean_frag_len_trunc);
 
+// XXX: DEPRECATED. See overloaded function below.
 std::vector<double> calc_eff_lens(const std::vector<int>& lengths, double mean);
 
 // @param lengths the lengths of all the targets
@@ -25,9 +26,10 @@ std::vector<double> calc_eff_lens(const std::vector<int>& lengths, double mean);
 std::vector<double> calc_eff_lens(const std::vector<int>& lengths,
     const std::vector<double>& means);
 
-std::vector<double> update_eff_lens(double mean, const MinCollector& tc,
+std::vector<double> update_eff_lens(const std::vector<double>& means,
+    const MinCollector& tc,
     const KmerIndex &index, const std::vector<double>& alpha,
-    const std::vector<double>& eff_lens, const std::vector<double>& means);
+    const std::vector<double>& eff_lens );
 
 
 WeightMap calc_weights(


### PR DESCRIPTION
This is a fix to do the "correct" calculation for effective length. What we had before was correct for targets near the tail end of the fragment length distribution, but wrong for short things. Often, this wasn't an issue, but even if you have some spurious alignments going to those things, the TPM would blow up.

Design:

- Compute the conditional mean fragment length up to the maximum length we store in the FLD (currently 1000bp)
- For each target, store it's 'conditional mean'. This vector get thrown around now instead of the 'mean'
- new eff_len_i = targ_len_i - mean_i + 1

On the cuffdiff2 dataset, it seems to fix some of the spurious big TPM values. Take a look at the short things around 2^6 - 2^7 length wise

Before:

![screen shot 2015-07-01 at 7 48 10 am](https://cloud.githubusercontent.com/assets/530217/8462126/63d84e92-1fe6-11e5-8f75-2d3649e68ccf.png)

After:

![screen shot 2015-07-01 at 7 48 37 am](https://cloud.githubusercontent.com/assets/530217/8462155/97076956-1fe6-11e5-88b5-bdd4f45503c6.png)

Simulations show a similar improvement.

Because we are now using a vector, for single-end data I just dump the user supplied frag len mean into every position. Maybe we should just throw a normal in there like everyone else? The tricky part will be the standard deviation. I think most people just pick something, but it might not be a bad idea to look at a few datasets and maybe cook together a table if it seems to be conditional on the mean.


**TODO**
- @pmelsted, the only thing I haven't done yet is to update the bias functions. I'm going to take a close look tomorrow, but it would be nice to have you look it over