### PR TITLE
fix number of paragraphs to be included in license

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -2,7 +2,7 @@ Copyright ©2015. The Regents of the University of California (Regents). All
 Rights Reserved. Permission to use, copy, modify, and distribute this software
 and its documentation for educational and research not-for-profit purposes,
 without fee and without a signed licensing agreement, is hereby granted,
-provided that the above copyright notice, this paragraph and the following two
+provided that the above copyright notice, this paragraph and the following three
 paragraphs appear in all copies, modifications, and distributions. Contact The
 Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue, Suite 510,
 Berkeley, CA 94720-1620, (510) 643-7201, for commercial licensing


### PR DESCRIPTION
the previous version would omit the paragraph starting with ```REGENTS SPECIFICALLY```