### PR TITLE
Bias to hdf5

### DIFF
--- a/src/EMAlgorithm.h
+++ b/src/EMAlgorithm.h
@@ -33,6 +33,7 @@ struct EMAlgorithm {
     ecmap_(index.ecmap),
     counts_(counts),
     target_names_(index.target_names_),
+    post_bias_(4096,1.0),
     alpha_(num_trans_, 1.0/num_trans_), // uniform distribution over targets
     rho_(num_trans_, 0.0),
     rho_set_(false),
@@ -72,7 +73,7 @@ struct EMAlgorithm {
     int i;
     for (i = 0; i < n_iter; ++i) {
       if (recomputeEffLen && (i == min_rounds || i == min_rounds + 500)) {
-        eff_lens_ = update_eff_lens(all_fl_means, tc_, index_, alpha_, eff_lens_);
+        eff_lens_ = update_eff_lens(all_fl_means, tc_, index_, alpha_, eff_lens_, post_bias_);
         weight_map_ = calc_weights (tc_.counts, ecmap_, eff_lens_);
       }
 
@@ -289,6 +290,7 @@ struct EMAlgorithm {
   const std::vector<std::string>& target_names_;
   const std::vector<double>& all_fl_means;
   std::vector<double> eff_lens_;
+  std::vector<double> post_bias_;
   WeightMap weight_map_;
   std::vector<double> alpha_;
   std::vector<double> alpha_before_zeroes_;

--- a/src/H5Writer.cpp
+++ b/src/H5Writer.cpp
@@ -1,8 +1,8 @@
 #include "H5Writer.h"
 
-void H5Writer::init(const std::string& fname, int num_bootstrap, int num_processed, uint compression,
-    size_t index_version, const std::string& shell_call,
-    const std::string& start_time)
+void H5Writer::init(const std::string& fname, int num_bootstrap, int num_processed,
+  const std::vector<int>& fld, uint compression, size_t index_version, 
+  const std::string& shell_call, const std::string& start_time)
 {
   primed_ = true;
   num_bootstrap_ = num_bootstrap;
@@ -19,7 +19,8 @@ void H5Writer::init(const std::string& fname, int num_bootstrap, int num_process
   std::vector<int> n_proc {num_processed};
   vector_to_h5(n_proc, aux_, "num_processed", false, compression_);
 
-  
+  vector_to_h5(fld, aux_, "fld", false, compression_);
+
   // info about run
   std::vector<std::string> kal_version{ KALLISTO_VERSION };
   vector_to_h5(kal_version, aux_, "kallisto_version", true, compression_);
@@ -73,7 +74,7 @@ H5Converter::H5Converter(const std::string& h5_fname, const std::string& out_dir
   // <aux info>
   // read target ids
   read_dataset(aux_, "ids", targ_ids_);
-  std::cerr << "[h5dump] number of targets: " << targ_ids_.size() << 
+  std::cerr << "[h5dump] number of targets: " << targ_ids_.size() <<
     std::endl;
 
   n_targs_ = targ_ids_.size();
@@ -94,7 +95,7 @@ H5Converter::H5Converter(const std::string& h5_fname, const std::string& out_dir
   read_dataset(aux_, "num_processed", n_proc_vec);
   n_proc_ = n_proc_vec[0];
 
-  
+
   std::cerr << "[h5dump] number of bootstraps: " << n_bs_ << std::endl;
   // </aux info>
   if (n_bs_ > 0) {

--- a/src/H5Writer.cpp
+++ b/src/H5Writer.cpp
@@ -1,7 +1,7 @@
 #include "H5Writer.h"
 
 void H5Writer::init(const std::string& fname, int num_bootstrap, int num_processed,
-  const std::vector<int>& fld, uint compression, size_t index_version, 
+  const std::vector<int>& fld,const std::vector<int>& preBias, uint compression, size_t index_version,
   const std::string& shell_call, const std::string& start_time)
 {
   primed_ = true;
@@ -20,6 +20,8 @@ void H5Writer::init(const std::string& fname, int num_bootstrap, int num_process
   vector_to_h5(n_proc, aux_, "num_processed", false, compression_);
 
   vector_to_h5(fld, aux_, "fld", false, compression_);
+
+  vector_to_h5(preBias, aux_, "bias_observed", false, compression_);
 
   // info about run
   std::vector<std::string> kal_version{ KALLISTO_VERSION };

--- a/src/H5Writer.cpp
+++ b/src/H5Writer.cpp
@@ -1,7 +1,8 @@
 #include "H5Writer.h"
 
 void H5Writer::init(const std::string& fname, int num_bootstrap, int num_processed,
-  const std::vector<int>& fld,const std::vector<int>& preBias, uint compression, size_t index_version,
+  const std::vector<int>& fld,const std::vector<int>& preBias, const std::vector<double>& postBias,
+  uint compression, size_t index_version,
   const std::string& shell_call, const std::string& start_time)
 {
   primed_ = true;
@@ -22,6 +23,8 @@ void H5Writer::init(const std::string& fname, int num_bootstrap, int num_process
   vector_to_h5(fld, aux_, "fld", false, compression_);
 
   vector_to_h5(preBias, aux_, "bias_observed", false, compression_);
+
+  vector_to_h5(postBias, aux_, "bias_normalized", false, compression_);
 
   // info about run
   std::vector<std::string> kal_version{ KALLISTO_VERSION };

--- a/src/H5Writer.h
+++ b/src/H5Writer.h
@@ -11,9 +11,9 @@ class H5Writer {
     H5Writer() : primed_(false) {}
     ~H5Writer();
 
-    void init(const std::string& fname, int num_bootstrap, int num_processed, uint compression,
-        size_t index_version, const std::string& shell_call,
-        const std::string& start_time);
+    void init(const std::string& fname, int num_bootstrap, int num_processed,
+      const std::vector<int>& fld, uint compression, size_t index_version,
+      const std::string& shell_call, const std::string& start_time);
 
     void write_main(const EMAlgorithm& em,
         const std::vector<std::string>& targ_ids,

--- a/src/H5Writer.h
+++ b/src/H5Writer.h
@@ -12,7 +12,7 @@ class H5Writer {
     ~H5Writer();
 
     void init(const std::string& fname, int num_bootstrap, int num_processed,
-      const std::vector<int>& fld, const std::vector<int>& preBias, uint compression, size_t index_version,
+      const std::vector<int>& fld, const std::vector<int>& preBias, const std::vector<double>& postBias, uint compression, size_t index_version,
       const std::string& shell_call, const std::string& start_time);
 
     void write_main(const EMAlgorithm& em,

--- a/src/H5Writer.h
+++ b/src/H5Writer.h
@@ -12,7 +12,7 @@ class H5Writer {
     ~H5Writer();
 
     void init(const std::string& fname, int num_bootstrap, int num_processed,
-      const std::vector<int>& fld, uint compression, size_t index_version,
+      const std::vector<int>& fld, const std::vector<int>& preBias, uint compression, size_t index_version,
       const std::string& shell_call, const std::string& start_time);
 
     void write_main(const EMAlgorithm& em,

--- a/src/ProcessReads.cpp
+++ b/src/ProcessReads.cpp
@@ -256,13 +256,13 @@ void ReadProcessor::processBuffer() {
   bool findFragmentLength = (mp.opt.fld == 0) && (mp.tlencount < 10000);
 
   int flengoal = 0;
+  flens.clear();
   if (findFragmentLength) {
     flengoal = (10000 - mp.tlencount);
     if (flengoal <= 0) {
       findFragmentLength = false;
       flengoal = 0;
     } else {
-      flens.clear();
       flens.resize(tc.flens.size(), 0);
     }
   }
@@ -272,12 +272,12 @@ void ReadProcessor::processBuffer() {
 
 
   int biasgoal  = 0;
+  bias5.clear();
   if (findBias) {
     biasgoal = (mp.maxBiasCount - mp.biasCount);
     if (biasgoal <= 0) {
       findBias = false;
     } else {
-      bias5.clear();
       bias5.resize(tc.bias5.size(),0);
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -802,7 +802,9 @@ int main(int argc, char *argv[]) {
           auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
           auto sd_fl = opt.sd;
           collection.init_mean_fl_trunc( mean_fl, sd_fl );
-          fld.resize(MAX_FRAG_LEN,0); // no obersvations
+          //fld.resize(MAX_FRAG_LEN,0); // no obersvations
+          fld = trunc_gaussian_counts(0, MAX_FRAG_LEN, mean_fl, sd_fl, 10000);
+
           // for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
           //   cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
           // }
@@ -912,8 +914,9 @@ int main(int argc, char *argv[]) {
           auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
           auto sd_fl = opt.sd;
           collection.init_mean_fl_trunc( mean_fl, sd_fl );
-          cout << collection.mean_fl_trunc.size() << endl;
-          fld.resize(MAX_FRAG_LEN,0);
+          //cout << collection.mean_fl_trunc.size() << endl;
+          //fld.resize(MAX_FRAG_LEN,0);
+          fld = trunc_gaussian_counts(0, MAX_FRAG_LEN, mean_fl, sd_fl, 10000);
           // for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
           //   cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
           // }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -808,6 +808,11 @@ int main(int argc, char *argv[]) {
           // }
         }
 
+        std::vector<int> preBias(4096,1);
+        if (opt.bias) {
+          preBias = collection.bias5; // copy
+        }
+
         auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);
 
         /*for (int i = 0; i < collection.bias3.size(); i++) {
@@ -821,7 +826,7 @@ int main(int argc, char *argv[]) {
 
         H5Writer writer;
         if (!opt.plaintext) {
-          writer.init(opt.output + "/abundance.h5", opt.bootstrap, num_processed, fld, 6,
+          writer.init(opt.output + "/abundance.h5", opt.bootstrap, num_processed, fld, preBias, 6,
               index.INDEX_VERSION, call, start_time);
           writer.write_main(em, index.target_names_, index.target_lens_);
         }
@@ -914,6 +919,12 @@ int main(int argc, char *argv[]) {
           // }
         }
 
+        std::vector<int> preBias(4096,1); // default
+        if (opt.bias) {
+          // fetch the observed bias
+          preBias = collection.bias5; // copy
+        }
+
         auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);
 
         EMAlgorithm em(collection.counts, index, collection, fl_means);
@@ -924,7 +935,7 @@ int main(int argc, char *argv[]) {
 
         if (!opt.plaintext) {
           // setting num_processed to 0 because quant-only is for debugging/special ops
-          writer.init(opt.output + "/abundance.h5", opt.bootstrap, 0, fld, 6,
+          writer.init(opt.output + "/abundance.h5", opt.bootstrap, 0, fld, preBias, 6,
               index.INDEX_VERSION, call, start_time);
           writer.write_main(em, index.target_names_, index.target_lens_);
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -826,7 +826,7 @@ int main(int argc, char *argv[]) {
 
         H5Writer writer;
         if (!opt.plaintext) {
-          writer.init(opt.output + "/abundance.h5", opt.bootstrap, num_processed, fld, preBias, 6,
+          writer.init(opt.output + "/abundance.h5", opt.bootstrap, num_processed, fld, preBias, em.post_bias_, 6,
               index.INDEX_VERSION, call, start_time);
           writer.write_main(em, index.target_names_, index.target_lens_);
         }
@@ -935,7 +935,7 @@ int main(int argc, char *argv[]) {
 
         if (!opt.plaintext) {
           // setting num_processed to 0 because quant-only is for debugging/special ops
-          writer.init(opt.output + "/abundance.h5", opt.bootstrap, 0, fld, preBias, 6,
+          writer.init(opt.output + "/abundance.h5", opt.bootstrap, 0, fld, preBias, em.post_bias_, 6,
               index.INDEX_VERSION, call, start_time);
           writer.write_main(em, index.target_names_, index.target_lens_);
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -794,12 +794,15 @@ int main(int argc, char *argv[]) {
         }
 
         // if mean FL not provided, estimate
+        std::vector<int> fld;
         if (opt.fld == 0.0) {
+          fld = collection.flens; // copy
           collection.compute_mean_frag_lens_trunc();
         } else {
           auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
           auto sd_fl = opt.sd;
           collection.init_mean_fl_trunc( mean_fl, sd_fl );
+          fld.resize(MAX_FRAG_LEN,0); // no obersvations
           // for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
           //   cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
           // }
@@ -818,7 +821,7 @@ int main(int argc, char *argv[]) {
 
         H5Writer writer;
         if (!opt.plaintext) {
-          writer.init(opt.output + "/abundance.h5", opt.bootstrap, num_processed, 6,
+          writer.init(opt.output + "/abundance.h5", opt.bootstrap, num_processed, fld, 6,
               index.INDEX_VERSION, call, start_time);
           writer.write_main(em, index.target_names_, index.target_lens_);
         }
@@ -895,14 +898,17 @@ int main(int argc, char *argv[]) {
         MinCollector collection(index, opt);
         collection.loadCounts(opt);
 
+        std::vector<int> fld;
         // if mean FL not provided, estimate
         if (opt.fld == 0.0) {
           collection.compute_mean_frag_lens_trunc();
+          fld = collection.flens;
         } else {
           auto mean_fl = (opt.fld > 0.0) ? opt.fld : collection.get_mean_frag_len();
           auto sd_fl = opt.sd;
           collection.init_mean_fl_trunc( mean_fl, sd_fl );
           cout << collection.mean_fl_trunc.size() << endl;
+          fld.resize(MAX_FRAG_LEN,0);
           // for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
           //   cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
           // }
@@ -918,7 +924,7 @@ int main(int argc, char *argv[]) {
 
         if (!opt.plaintext) {
           // setting num_processed to 0 because quant-only is for debugging/special ops
-          writer.init(opt.output + "/abundance.h5", opt.bootstrap, 0, 6,
+          writer.init(opt.output + "/abundance.h5", opt.bootstrap, 0, fld, 6,
               index.INDEX_VERSION, call, start_time);
           writer.write_main(em, index.target_names_, index.target_lens_);
         } else {

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -102,7 +102,8 @@ std::vector<double> update_eff_lens(
     const MinCollector& tc,
     const KmerIndex &index,
     const std::vector<double>& alpha,
-    const std::vector<double>& eff_lens
+    const std::vector<double>& eff_lens,
+    std::vector<double>& dbias5
     ) {
 
   double biasDataNorm = 0.0;
@@ -112,7 +113,8 @@ std::vector<double> update_eff_lens(
     biasDataNorm += tc.bias5[i];
   }
 
-  std::vector<double> dbias5(num6mers);
+  dbias5.clear();
+  dbias5.resize(num6mers, 0.0); // clear the bias
 
   index.loadTranscriptSequences();
 

--- a/src/weights.cpp
+++ b/src/weights.cpp
@@ -253,3 +253,28 @@ std::vector<double> trunc_gaussian_fld(int start, int stop, double mean,
 
   return mean_fl;
 }
+
+std::vector<int> trunc_gaussian_counts(int start, int stop, double mean,
+    double sd, int total_count) {
+  size_t n = stop - start;
+  std::vector<int> obs_fl(n, 0);
+
+  double total_mass = 0.0;
+
+
+  for (size_t i = 0; i < n; ++i) {
+    double x = static_cast<double>(start + i);
+    x = (x - mean) / sd;
+    double cur_density = std::exp( - 0.5 * x * x ) / sd;
+    total_mass += cur_density;
+  }
+
+  for (size_t i = 0; i < n; ++i) {
+    double x = static_cast<double>(start + i);
+    x = (x - mean) / sd;
+    double cur_density = std::exp( - 0.5 * x * x ) / sd;
+    obs_fl[i] = (int) std::round(cur_density * total_count / total_mass);
+  }
+
+  return obs_fl;
+}

--- a/src/weights.h
+++ b/src/weights.h
@@ -29,7 +29,7 @@ std::vector<double> calc_eff_lens(const std::vector<int>& lengths,
 std::vector<double> update_eff_lens(const std::vector<double>& means,
     const MinCollector& tc,
     const KmerIndex &index, const std::vector<double>& alpha,
-    const std::vector<double>& eff_lens );
+    const std::vector<double>& eff_lens, std::vector<double>& post_bias );
 
 
 WeightMap calc_weights(

--- a/src/weights.h
+++ b/src/weights.h
@@ -48,4 +48,8 @@ WeightMap calc_weights(
 std::vector<double> trunc_gaussian_fld(int start, int stop, double mean,
     double sd);
 
+std::vector<int> trunc_gaussian_counts(int start, int stop, double mean,
+        double sd, int total_count);
+
+
 #endif // KALLISTO_WEIGHTS_H


### PR DESCRIPTION
This PR creates 3 new fields in the HDF5 output.

- fld the fragment length distribution counts
- bias_observed the observed counts for each 6-mer
- bias_normalized the counts of 6-mers normalizes with respect to the abundances of transcripts

In case the fld was not estimated from the data, an all zeros vector is written

In case the bias was not estimated from the data an all ones vector is written for both the bias vectors.