### PR TITLE
Fixed build failure on OSX because of bad include path, see #121

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
 endif( ZLIB_FOUND )
 
 if(HDF5_FOUND)
-    include_directories( ${HDF5_INCLUDE_DIR} )
+    include_directories( ${HDF5_INCLUDE_DIRS} )
     target_link_libraries( kallisto_core ${HDF5_LIBRARIES} )
     target_link_libraries( kallisto ${HDF5_LIBRARIES} )
 else()


### PR DESCRIPTION
This corrects a typo in `src/CMakeLists.txt` and sets the include directory for the HDF5 library correctly.
This fixes Issue #121 .