### PR TITLE
Fix CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,20 +2,31 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(kallisto)
 
+include(GNUInstallDirs)
+
 set(EXT_PROJECTS_DIR ${PROJECT_SOURCE_DIR}/ext)
+set(CMAKE_CXX_FLAGS_PROFILE "-g")
+
+# Set Release type for builds where CMAKE_BUILD_TYPE is unset
+# This is usually a good default as this implictly enables
+#
+#   CXXFLAGS = -O3 -DNDEBUG
+#
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+if(${CMAKE_VERSION} VERSION_LESS 3.1)
+    # CMake versions before 3.1 do not understand CMAKE_CXX_STANDARD
+    # remove this block once CMake >=3.1 has fixated in the ecosystem
+    add_compile_options(-std=c++11)
+else()
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 
 #add_compile_options(-Wall -Wno-unused-function)
-add_compile_options(-std=c++11)
-IF(CMAKE_BUILD_TYPE MATCHES Debug)
-    message("debug mode")
-		add_compile_options(-O0 -g)
-ELSE(CMAKE_BUILD_TYPE MATCHES Debug)
-		add_compile_options(-O3)
-ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
-
-if(CMAKE_BUILD_TYPE MATCHES Profile)
-	add_compile_options(-g)
-endif(CMAKE_BUILD_TYPE MATCHES Profile)
 
 if(LINK MATCHES static)
     message("static build")
@@ -28,12 +39,14 @@ ENDIF(LINK MATCHES static)
 add_subdirectory(src)
 include_directories(${EXT_PROJECTS_DIR})
 
+option(BUILD_TESTING "Build unit tests." OFF)
+include(CTest)
+
 if (BUILD_TESTING)
     add_subdirectory(${EXT_PROJECTS_DIR}/catch)
 
     # Includes Catch in the project:
     include_directories(${CATCH_INCLUDE_DIR} ${COMMON_INCLUDES})
-    enable_testing(true)  # Enables unit-testing.
 
     add_subdirectory(unit_tests)
 endif(BUILD_TESTING)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,4 +57,4 @@ endif(LINK MATCHES static)
 
 
 
-install(TARGETS kallisto DESTINATION bin)
+install(TARGETS kallisto DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ project(Tests)
 file(GLOB sources *.cpp)
 
 add_executable(tests ${sources})
+add_test(unittest tests)
 
 find_package( ZLIB REQUIRED )
 if ( ZLIB_FOUND )
@@ -15,6 +16,7 @@ endif( ZLIB_FOUND )
 
 target_link_libraries(tests kallisto_core)
 
+find_package( HDF5 REQUIRED )
 if(HDF5_FOUND)
     include_directories( ${HDF5_INCLUDE_DIR} )
     target_link_libraries( tests ${HDF5_LIBRARIES} )

--- a/unit_tests/test_kmerhashtable.cpp
+++ b/unit_tests/test_kmerhashtable.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Build table", "[build_table]")
 
 		std::random_device rd;
     std::mt19937 gen(rd());
-    std::uniform_int_distribution<double> dis(1, 100);
+    std::uniform_int_distribution<int> dis(1, 100);
 		
     // TODO: figure out a better way to deal with initialization
     Kmer::set_k(global_opts.k);


### PR DESCRIPTION
* Respect user variables. Set default `CMAKE_BUILD_TYPE`, and
  do not override user `CXXFLAGS`.
* Use `GNUInstallDirs` to allow changing directory where
  kallisto gets installed to.
* Use modern CMake idioms to detect C++11, which is more
  generalizable than adding `-std=c++11` unconditionally.
* Fix some minor C++ issues for building unit tests.