### PR TITLE
Added missing autoconf commands for htslib

### DIFF
--- a/source.md
+++ b/source.md
@@ -53,6 +53,20 @@ Run cmake:
 
 `cmake ..`
 
+Run autotools toolchain on `ext/htslib`:
+
+`cd ../ext/htslib`
+
+`aclocal`
+
+`autoconf`
+
+`autoheader`
+
+`automake --add-missing`
+
+`cd ../../build`
+
 Build the code:
 
 `make`


### PR DESCRIPTION
At least on Debian 9 `ext/htslib` folder doesn't contain `configure`, `config.h.in` and friends after running `cmake`. Thus, I had to manually run standard autoconf steps to build the project. Several people slipped on that stage as well.

Thank you!