### PR TITLE
Update match function

### DIFF
--- a/src/KmerIndex.cpp
+++ b/src/KmerIndex.cpp
@@ -1096,7 +1096,7 @@ void KmerIndex::match(const char *s, int l, std::vector<std::pair<KmerEntry, int
           auto search2 = kmap.find(rep2);
           bool found2 = false;
           int  found2pos = pos+dist;
-          if (search2 == kmap.end()) {
+          if (search2 != kmap.end()) {
             found2=true;
             found2pos = pos;
           } else if (val.contig == search2->second.contig) {

--- a/src/KmerIndex.cpp
+++ b/src/KmerIndex.cpp
@@ -1099,6 +1099,7 @@ void KmerIndex::match(const char *s, int l, std::vector<std::pair<KmerEntry, int
           if (search2 != kmap.end()) {
             found2=true;
             found2pos = pos;
+            v.push_back({search2->second, kit2->second});
           } else if (val.contig == search2->second.contig) {
             found2=true;
             found2pos = pos+dist;


### PR DESCRIPTION
# __Short explanation__
In the following lines at kmerindex::match() function the right logic in the if condition is followed.
Lines: [L1069](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1069), [L1128](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1128), [L1178](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1178), [L1195](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1195)
`!= kmap.end()` is equivalent to `// if k-mer found`
and if `!= kmap.end()` returns `true` that means __*search*__ variables contains result of successfull alignment in the hashTable so the following [Line#1100](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1100) the `found2` flag state changed to be `true` as an indication that `search2` has kmer match while the condition `== kmap.end()` check if __kmer not found__ then raise the flag.
So, in the [Line#1099](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1099) the condition needs to be fixed to check if the `search2` has `kmer match` by changing the `==` to `!=`
> **Summary**: Check if __*kmer is found*__ instead of checking if the *__~~kmer is not found~~__*

---
# __Detailed explanation__

## Data used in the test
## __1- Reference__

| File name | Description | Visualize TDBG |
| ------ | ------ | ------ |
| [Reference 1](https://github.com/abuelanin/kallisto/blob/master/my_test_data/references_sequences/reference1.fa) | Four Unique Transcripts | [GFA](https://raw.githubusercontent.com/abuelanin/kallisto/master/my_test_data/Visualizations/reference1.png) |
| [Reference 2](https://github.com/abuelanin/kallisto/blob/master/my_test_data/references_sequences/reference2.fa) | Reference 1 + Deletion from Tr1 | [GFA](https://raw.githubusercontent.com/abuelanin/kallisto/master/my_test_data/Visualizations/reference2.png) |
| [Reference 3](https://github.com/abuelanin/kallisto/blob/master/my_test_data/references_sequences/reference3.fa) | Reference 2 + Fusion between Tr2 & Tr3 | [GFA](https://raw.githubusercontent.com/abuelanin/kallisto/master/my_test_data/Visualizations/reference3.png) |

## __2- Reads__
| File name | Description | Reference Index |
| ------ | ------ | ------ |
| [1.fa](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/1.fa) | R1 ⊂ Tr1, R2 ⊂ Tr2, R3 ⊂ Tr3, R4 ⊂ Tr4| reference1.idx |
| [2.fa](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/2.fa) | R1 ⊂ Tr1, R2 ⊂ Tr2, R3 ⊂ Tr3, R4 ⊂ Tr4, R5 ⊂ Tr5 | reference2.idx |
| [3.fa](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/3.fa) | R1 ⊂ (Tr1 & Tr5), R2 ⊂ Tr2, R3 ⊂ Tr3, R4 ⊂ Tr4, R5 ⊂ Tr5| reference2.idx |
| [4.fa](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/4.fa) | R1 ⊂ Tr1, R2 ⊂ Tr2, R3 ⊂ Tr3, R4 ⊂ Tr4, R5 ⊂ Tr5, R6 ⊂ Tr6 | reference3.idx |
| [5.fa](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/5.fa) |R1 ⊂ Tr1, R2 ⊂ Tr2, R3 ⊂ Tr3, R4 ⊂ Tr4, R5 ⊂ Tr5, R6 ⊂ (Tr6 & Tr2)| reference3.idx |
| [6.fa](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/6.fa) | R1 ⊂ Tr1, R2 ⊂ Tr2, R3 ⊂ Tr3, R4 ⊂ Tr4, R5 ⊂ Tr5, R6 ⊂ (Tr2 & Tr3)| reference2.idx |

> Each read is 100pb

The unexpected behavior happends when pseudo-aligning the [6.fa ](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/6.fa) with [reference1](https://github.com/abuelanin/kallisto/blob/master/my_test_data/references_sequences/reference1.fa) which has the original 4 unique transcripts.
 
## __3- Results__

#### [__Vector V after pseudo-alignment__](https://github.com/pachterlab/kallisto/blob/master/src/MinCollector.cpp#L152)
>Original master
##### (Debugging_Print)  SORTED KmerEntry vector(V)
``` C
KmerEntry: pos:91 | contig: 2 | contig_Length: 2588 | read_pos: 0
KmerEntry: pos:92 | contig: 2 | contig_Length: 2588 | read_pos: 1
KmerEntry: pos:93 | contig: 2 | contig_Length: 2588 | read_pos: 2
KmerEntry: pos:94 | contig: 2 | contig_Length: 2588 | read_pos: 3
KmerEntry: pos:95 | contig: 2 | contig_Length: 2588 | read_pos: 4
KmerEntry: pos:106 | contig: 3 | contig_Length: 965 | read_pos: 2496
```
The last `read_pos` is equal to `2496` while the read length is `100pb` !

> After the edit `!=kmap.end()`
``` C
KmerEntry: pos:91 | contig: 2 | contig_Length: 2588 | read_pos: 0
KmerEntry: pos:91 | contig: 2 | contig_Length: 2588 | read_pos: 0
```
> After the edit `!=kmap.end()` & `v.push_back({search2->second, kit2->second});`
``` C
KmerEntry: pos:91 | contig: 2 | contig_Length: 2588 | read_pos: 0
KmerEntry: pos:91 | contig: 2 | contig_Length: 2588 | read_pos: 0
KmerEntry: pos:139 | contig: 3 | contig_Length: 965 | read_pos: 69
```
That makes sense, there's no need in this case to enter the [this is weird, let's try the middle k-mer](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1116) section or to [backOff](https://github.com/pachterlab/kallisto/blob/master/src/KmerIndex.cpp#L1168)

---

### Side Note
This bug was discovered unintentionally when adding the option __Union__ of Compatibility classes instead of the default __Intersect__ 
[![NSolid](https://raw.githubusercontent.com/abuelanin/kallisto/master/my_test_data/other/union.png)](https://raw.githubusercontent.com/abuelanin/kallisto/master/my_test_data/other/union.png)
To be able to create new compatibility classes if there's no intersection between two transcripts in the reference just like when pseudo-aligning the [6.fa ](https://github.com/abuelanin/kallisto/blob/master/my_test_data/reads/6.fa) on [reference1](https://github.com/abuelanin/kallisto/blob/master/my_test_data/references_sequences/reference1.fa) or [reference2](https://github.com/abuelanin/kallisto/blob/master/my_test_data/references_sequences/reference2.fa)