### PR TITLE
Fix typos: `10x verison 2` > `10x version 2`, `inDrop` > `inDrops`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -528,12 +528,12 @@ void ListSingleCellTechnologies() {
   << "short name       description" << endl
   << "----------       -----------" << endl
   << "10xv1            10x version 1 chemistry" << endl
-  << "10xv2            10x verison 2 chemistry" << endl
+  << "10xv2            10x version 2 chemistry" << endl
   << "10xv3            10x version 3 chemistry" << endl
   << "CELSeq           CEL-Seq" << endl
   << "CELSeq2          CEL-Seq version 2" << endl
   << "DropSeq          DropSeq" << endl
-  << "inDrop           inDrop" << endl
+  << "inDrops          inDrops" << endl
   << "SCRBSeq          SCRB-Seq" << endl
   << "SureCell         SureCell for ddSEQ" << endl
   << endl;


### PR DESCRIPTION
Fix two typos:
`10x verison 2` > `10x version 2`
`inDrop` > `inDrops`
as can be seen on https://www.nature.com/articles/nprot.2016.154