### PR TITLE
pass user-defined bias argument to bootstrap estimations

### DIFF
--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -6,7 +6,7 @@ EMAlgorithm Bootstrap::run_em() {
     EMAlgorithm em(counts, index_, tc_, mean_fls_, opt);
 
     //em.set_start(em_start);
-    em.run(10000, 50, false, false);
+    em.run(10000, 50, false, opt.bias);
     /* em.compute_rho(); */
 
     return em;


### PR DESCRIPTION
in Bootstrap::run_em, EMAlgorithm::run is called with the fourth
argument set to false, that is without bias estimation even if the
user set the --bias option on command line. This causes in some cases
major discrepancies between the intial EM estimate and bootstrap
estimates, which renders the bootstrap estimates inadequate to
estimate the uncertainty of the abundance ML estimates (see #151 for
an example).

I should add that this fix is probably naive, as the bias estimate is done repeatedly for each bootstrap iteration. I've not benchmarked it properly, but the runs with this fix seemed to have a longer execution time. I'm happy to try and improve the patch if it can help. 