### PR TITLE
Provide optional strand-specificity flags for `kallisto bus`

### DIFF
--- a/src/ProcessReads.cpp
+++ b/src/ProcessReads.cpp
@@ -1482,21 +1482,14 @@ void BUSProcessor::processBuffer() {
     u.clear();
 
     // process 2nd read
-    index.match(seq,seqlen, v);
+    index.match(seq, seqlen, v);
 
     // collect the target information
     int ec = -1;
-    int r = tc.intersectKmers(v, v2, false,u);
-    if (!u.empty()) {      
-      ec = tc.findEC(u);
-    }
-      
+    int r = tc.intersectKmers(v, v2, false, u);
+    
     // optional strand-specificity
     if (mp.opt.strand_specific && !u.empty()) {
-      /* debugging
-      std::cerr << "[info] applying strand specificity" << std::endl;
-      */
-      
       int p = -1;
       Kmer km;
       KmerEntry val;
@@ -1504,7 +1497,7 @@ void BUSProcessor::processBuffer() {
       if (!v.empty()) {
         vtmp.clear();
         bool firstStrand = (mp.opt.strand == ProgramOptions::StrandType::FR);
-        p = findFirstMappingKmer(v,val);
+        p = findFirstMappingKmer(v, val);
         km = Kmer((seq+p));
         bool strand = (val.isFw() == (km == km.rep())); // k-mer maps to fw strand?
         // might need to optimize this
@@ -1541,7 +1534,7 @@ void BUSProcessor::processBuffer() {
         b.flags = (uint32_t) flags[i / jmax];
       }
 
-      //ec = tc.findEC(u);
+      ec = tc.findEC(u);
       
       // count the pseudoalignment
       if (ec == -1 || ec >= counts.size()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -546,6 +546,8 @@ void ListSingleCellTechnologies() {
 void ParseOptionsBus(int argc, char **argv, ProgramOptions& opt) {
   int verbose_flag = 0;
   int gbam_flag = 0;
+  int strand_FR_flag = 0;
+  int strand_RF_flag = 0;
 
   const char *opt_string = "i:o:x:t:lbng:c:";
   static struct option long_options[] = {
@@ -560,6 +562,8 @@ void ParseOptionsBus(int argc, char **argv, ProgramOptions& opt) {
     {"genomebam", no_argument, &gbam_flag, 1},
     {"gtf", required_argument, 0, 'g'},
     {"chromosomes", required_argument, 0, 'c'},
+    {"fr-stranded", no_argument, &strand_FR_flag, 1},
+    {"rf-stranded", no_argument, &strand_RF_flag, 1},
     {0,0,0,0}
   };
 
@@ -631,6 +635,15 @@ void ParseOptionsBus(int argc, char **argv, ProgramOptions& opt) {
     opt.genomebam = true;    
   }
 
+  if (strand_FR_flag) {
+    opt.strand_specific = true;
+    opt.strand = ProgramOptions::StrandType::FR;
+  }
+  
+  if (strand_RF_flag) {
+    opt.strand_specific = true;
+    opt.strand = ProgramOptions::StrandType::RF;
+  }
   
   // all other arguments are fast[a/q] files to be read
   for (int i = optind; i < argc; i++) {
@@ -1725,6 +1738,8 @@ void usageBus() {
        << "-t, --threads=INT             Number of threads to use (default: 1)" << endl
        << "-b, --bam                     Input file is a BAM file" << endl
        << "-n, --num                     Output number of read in flag column (incompatible with --bam)" << endl
+       << "    --fr-stranded             Strand specific reads, sequence read forward" << endl
+       << "    --rf-stranded             Strand specific reads, sequence read reverse" << endl
        << "    --verbose                 Print out progress information every 1M proccessed reads" << endl;
 }
 


### PR DESCRIPTION
### Purpose
This pull request extends `kallisto bus` to have optional functionality to associate reads to ECs based on transcript strand. This is largely achieved with the code already existing for handling strandedness in `kallisto quant`. This pull request leaves the default behavior unchanged, while adding an option to use `--fr-stranded` or `--rf-stranded` flags in the `kallisto bus` command.

### Flag Orientation
Since the actual sequence read may be on the first or second read depending on the technology, I decided to code it such that `--fr-stranded` means the sequence read is sense with the transcript and `--rf-stranded` means anti-sense. As an example, all 10X Chromium 3'-end versions would use `--fr-stranded` because the sequence read is sense with the transcript, despite being located in R2.

### Future Direction
Perhaps a more practical interface would be to provide only a single flag (e.g., `--stranded`) and have the direction encoded with the technology info (e.g., like the BC/UMI location info).

### Misc
As a technical note, the deletion of lines 1490-91 in `ProcessReads.cpp` is counterbalanced by uncommenting the `findEC` step later in the code (1509/1537). As far as I can tell, it was unnecessary to have the earlier one run, but it was essential to compute it after removing strand ambiguities.