### PR TITLE
Fix GCC-11 Build Failure: include limits lib

### DIFF
--- a/src/MinCollector.h
+++ b/src/MinCollector.h
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <vector>
 #include <unordered_map>
+#include <limits>
 
 #include "KmerIndex.h"
 #include "weights.h"


### PR DESCRIPTION
Hi,

currently kallisto doesn't build with gcc-11 and output the following error:

```
[ 47%] Building CXX object src/CMakeFiles/kallisto_core.dir/MinCollector.cpp.o
cd /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src && /usr/bin/g++-11  -I/<<PKGBUILDDIR>>/src -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -std=c++11 -o CMakeFiles/kallisto_core.dir/MinCollector.cpp.o -c /<<PKGBUILDDIR>>/src/MinCollector.cpp
/<<PKGBUILDDIR>>/src/MinCollector.cpp: In member function ‘std::vector<int> MinCollector::intersectECs(std::vector<std::pair<KmerEntry, int> >&) const’:
/<<PKGBUILDDIR>>/src/MinCollector.cpp:194:21: error: ‘numeric_limits’ is not a member of ‘std’
  194 |   int minpos = std::numeric_limits<int>::max();
      |                     ^~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/MinCollector.cpp:194:36: error: expected primary-expression before ‘int’
  194 |   int minpos = std::numeric_limits<int>::max();
      |                                    ^~~
/<<PKGBUILDDIR>>/src/MinCollector.cpp: In member function ‘double MinCollector::get_mean_frag_len(bool) const’:
/<<PKGBUILDDIR>>/src/MinCollector.cpp:294:19: error: ‘numeric_limits’ is not a member of ‘std’
  294 |       return std::numeric_limits<double>::max();
      |                   ^~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/MinCollector.cpp:294:34: error: expected primary-expression before ‘double’
  294 |       return std::numeric_limits<double>::max();
      |                                  ^~~~~~
/<<PKGBUILDDIR>>/src/MinCollector.cpp:294:34: error: expected ‘;’ before ‘double’
  294 |       return std::numeric_limits<double>::max();
      |                                  ^~~~~~
      |                                  ;
/<<PKGBUILDDIR>>/src/MinCollector.cpp:294:40: error: expected unqualified-id before ‘>’ token
  294 |       return std::numeric_limits<double>::max();
      |                                        ^
make[3]: *** [src/CMakeFiles/kallisto_core.dir/build.make:202: src/CMakeFiles/kallisto_core.dir/MinCollector.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu'
make[2]: *** [CMakeFiles/Makefile2:145: src/CMakeFiles/kallisto_core.dir/all] Error 2
make[2]: Leaving directory '/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu'
make[1]: *** [Makefile:152: all] Error 2
make[1]: Leaving directory '/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu'
```


This PR is an attempt to fix it -- it builds on applying this patch