### PR TITLE
Add missing <limits> header

### DIFF
--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -1,5 +1,6 @@
 #include "MinCollector.h"
 #include <algorithm>
+#include <limits>
 
 // utility functions
 


### PR DESCRIPTION
`std::numeric_limits` requires this header. I know that #317 includes this change, but this makes the project build again.