### PR TITLE
EM priors

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -145,6 +145,7 @@ struct ProgramOptions {
   std::string fldFile;
   std::string transcriptsFile;
   std::string genemap;
+  std::string priors;
 
 ProgramOptions() :
   verbose(false),
@@ -183,7 +184,8 @@ ProgramOptions() :
   inspect_thorough(false),
   single_overhang(false),
   aa(false),
-  distinguish(false)
+  distinguish(false),
+  priors("")
   {}
 };
 


### PR DESCRIPTION
This PR adds the options to supply priors to the EM algorithm. The priors are supplied as a text file to `quant` and `quant-tcc` , using the `--priors` option. The file contains line separated numbers in the same order as the transcripts used to build the index.

If the sum of the numbers in the file is greater than 1 (+ eps), we assume that raw counts are supplied instead of probabilities. In this case, we add a pseudocount to each number and then normalize them to sum to one. The pseudocount is added to prevent zero valued priors, because the EM algorithm cannot recover from that (i.e. with a zero prior, alpha will always be zero for that transcript).

However, if the sum of the numbers in the file is less than or equal to 1 (+ eps), we assume them to be probabilities and use them as is. In this case it is up to the user to ensure that no zero priors are present.

If no `--priors` file is supplied, the program will default to uniform priors as before.