### PR TITLE
Added option to change d-list overhang

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -115,6 +115,7 @@ struct ProgramOptions {
   std::vector<std::string> batch_ids;
   std::vector<std::string> files;
   std::vector<std::string> d_list;
+  int d_list_overhang;
   bool plaintext;
   bool write_index;
   bool single_end;
@@ -183,7 +184,8 @@ ProgramOptions() :
   inspect_thorough(false),
   single_overhang(false),
   aa(false),
-  distinguish(false)
+  distinguish(false),
+  d_list_overhang(1)
   {}
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,6 +134,7 @@ void ParseOptionsIndex(int argc, char **argv, ProgramOptions& opt) {
   }
   if (aa_flag) {
     opt.aa = true;
+    if (opt.d_list_overhang < 3) opt.d_list_overhang = 3;
   }
   if (distinguish_flag) {
     opt.distinguish = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,7 @@ void ParseOptionsIndex(int argc, char **argv, ProgramOptions& opt) {
     {"ec-max-size", required_argument, 0, 'e'},
     {"threads", required_argument, 0, 't'},
     {"d-list", required_argument, 0, 'd'},
+    {"d-list-overhang", required_argument, 0, 'D'}, // Do we have to have a one-letter flag as well?
     {0,0,0,0}
   };
   int c;
@@ -115,6 +116,10 @@ void ParseOptionsIndex(int argc, char **argv, ProgramOptions& opt) {
       while (std::getline(ss, filename, ',')) { 
         opt.d_list.push_back(filename);
       }
+      break;
+    }
+    case 'D': {
+      stringstream(optarg) >> opt.d_list_overhang;
       break;
     }
     default: break;


### PR DESCRIPTION
This branch implements the option to manually control how long the d-list overhang on either side of each unitig should be. Pass in a (>0) integer via the `--d-list-overhang` flag.