### PR TITLE
All D-list transcripts have the same ID

### DIFF
--- a/src/BlockArray.hpp
+++ b/src/BlockArray.hpp
@@ -370,8 +370,14 @@ class BlockArray {
         }
 
         void print() const {
-            for (const auto& b : poly) {
-                std::cout << "[" << b.lb << ", " << b.ub << "): " << b.val << ", ";
+
+            if (flag == 0) return;
+            if (flag == 1) {
+                std::cout << "[" << mono.lb << ", " << mono.ub << "): " << mono.val;
+            } else {
+                for (const auto& b : poly) {
+                    std::cout << "[" << b.lb << ", " << b.ub << "): " << b.val << ", ";
+                }
             }
             std::cout << std::endl;
         }

--- a/src/KmerIndex.cpp
+++ b/src/KmerIndex.cpp
@@ -451,11 +451,6 @@ void KmerIndex::BuildDistinguishingGraph(const ProgramOptions& opt, std::ofstrea
       tr.stop  = um.dist + um.len;
 
       trinfos[n->id].push_back(tr);
-
-      // DEBUG:
-      // std::cout << tr.trid << " " << n->id << ": " << um.strand << " " << tr.start << " " << tr.stop << " ";
-      // std::cout << seq << " " << um.mappedSequenceToString() << " " << um.referenceUnitigToString();
-      // std::cout << std::endl;
     }
   }
   infile_a.close();
@@ -873,7 +868,7 @@ void KmerIndex::BuildEquivalenceClasses(const ProgramOptions& opt, const std::st
       }
       TRInfo tr;
 
-      tr.trid = j;
+      tr.trid = std::min<size_t>(j, onlist_sequences.cardinality());
       tr.pos = (proc-um.len) | (!um.strand ? sense : missense);
       tr.start = um.dist;
       tr.stop  = um.dist + um.len;
@@ -904,7 +899,6 @@ void KmerIndex::BuildEquivalenceClasses(const ProgramOptions& opt, const std::st
 
   std::cerr << "[build] target de Bruijn graph has k-mer length " << dbg.getK() << " and minimizer length "  << dbg.getG() << std::endl;
   std::cerr << "[build] target de Bruijn graph has " << dbg.size() << " contigs and contains "  << dbg.nbKmers() << " k-mers " << std::endl;
-  //std::cerr << "[build] target de Bruijn graph contains " << ecmapinv.size() << " equivalence classes from " << seqs.size() << " sequences." << std::endl;
 }
 
 void KmerIndex::PopulateMosaicECs(std::vector<std::vector<TRInfo> >& trinfos) {
@@ -1781,8 +1775,6 @@ std::pair<int,bool> KmerIndex::findPosition(int tr, Kmer km, const_UnitigMap<Nod
       ret = {trpos+padding-p, !csense}; // case II
     }
   }
-  // DEBUG:
-  //std::cout << std::to_string(ret.first) << " " << std::to_string(ret.second) << std::endl;
   return ret;
 }
 

--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -258,7 +258,6 @@ Roaring MinCollector::intersectECs(std::vector<std::pair<const_UnitigMap<Node>, 
         }
         r &= ec;
         if (r.isEmpty()) {
-          std::cerr << std::endl;
           return r;
         }
         lastEC = std::move(ec);
@@ -278,8 +277,6 @@ Roaring MinCollector::intersectECs(std::vector<std::pair<const_UnitigMap<Node>, 
   if ((maxpos-minpos + k) < min_range) {
     return {};
   }
-
-  std::cout << "Intersection found: " << r.toString() << std::endl;
 
   return r;
 }

--- a/src/MinCollector.cpp
+++ b/src/MinCollector.cpp
@@ -50,8 +50,6 @@ int MinCollector::intersectKmersCFC(std::vector<std::pair<const_UnitigMap<Node>,
 
   // If a single kmer matches perfectly in the host genome in any frame, throw out the entire read
   Roaring u1 = intersectECs(v1);
-  std::cerr << "u1 onlist cardinality: " << (u1 & index.onlist_sequences).cardinality() << endl;
-  std::cerr << "u1 total cardinality: " << u1.cardinality() << endl;
   if ((u1 & index.onlist_sequences).cardinality() != u1.cardinality()) return -1;
   Roaring u3 = intersectECs(v3);
   if ((u3 & index.onlist_sequences).cardinality() != u3.cardinality()) return -1;
@@ -233,6 +231,7 @@ Roaring MinCollector::intersectECs(std::vector<std::pair<const_UnitigMap<Node>, 
          }
        }); // sort by contig, and then first position
 
+  
   r = v[0].first.getData()->ec[v[0].first.dist].getIndices();
   bool found_nonempty = !r.isEmpty();
   Roaring lastEC = r;
@@ -244,6 +243,7 @@ Roaring MinCollector::intersectECs(std::vector<std::pair<const_UnitigMap<Node>, 
     if (!found_nonempty) {
       r = v[i].first.getData()->ec[v[i].first.dist].getIndices();
       found_nonempty = !r.isEmpty();
+      continue;
     }
 
     if (!v[i].first.isSameReferenceUnitig(v[i-1].first) ||
@@ -258,6 +258,7 @@ Roaring MinCollector::intersectECs(std::vector<std::pair<const_UnitigMap<Node>, 
         }
         r &= ec;
         if (r.isEmpty()) {
+          std::cerr << std::endl;
           return r;
         }
         lastEC = std::move(ec);
@@ -277,6 +278,8 @@ Roaring MinCollector::intersectECs(std::vector<std::pair<const_UnitigMap<Node>, 
   if ((maxpos-minpos + k) < min_range) {
     return {};
   }
+
+  std::cout << "Intersection found: " << r.toString() << std::endl;
 
   return r;
 }

--- a/src/ProcessReads.cpp
+++ b/src/ProcessReads.cpp
@@ -215,13 +215,6 @@ int64_t ProcessReads(MasterProcessor& MP, const  ProgramOptions& opt) {
     std::cerr << "[~warn] no reads pseudoaligned." << std::endl;
   }
 
-
-
-  /*
-  for (int i = 0; i < 4096; i++) {
-    std::cout << i << " " << tc.bias5[i] << " " << tc.bias3[i] << "\n";
-    }*/
-
   // write output to outdir
   if (opt.write_index) {
     std::string outfile = opt.output + "/counts.txt";
@@ -656,23 +649,6 @@ void MasterProcessor::processAln(const EMAlgorithm& em, bool useEM = true) {
     }
   }
 
-  // debug and show breakpoints
-  /*
-  std::cout << "bplimit = " << bpLimit << ", sum = " << sum << std::endl;
-  std::cout << "breakpoints (" << breakpoints.size() << ") = {" << std::endl;
-  for (auto &x : breakpoints) {
-    int32_t tid = (int32_t) (x >> 32);
-    int32_t pos = (int32_t) ((x >> 1) & (0xFFFF)) - 1;
-    std::string chr = "*";
-    if (tid != -1) {
-      chr = model.chr[tid].name;
-    }
-    std::cout << "  " << chr << " (" << model.chr[tid].len << ") : " << pos << std::endl;
-  }
-
-  std::cout << "}" << std::endl;
-  */
-
   assert(opt.pseudobam);
   pseudobatchf_in.open(opt.output + "/pseudoaln.bin", std::ios::in | std::ios::binary);
   SR->reset();
@@ -987,7 +963,6 @@ void ReadProcessor::processBuffer() {
         exit(1);
         //searchFusion(index,mp.opt,tc,mp,ec,names[i-1].first,s1,v1,names[i].first,s2,v2,paired);
       }
-      //std::cout << s1 << std::endl;
     }
 
     /* --  possibly modify the pseudoalignment  -- */
@@ -1556,7 +1531,6 @@ void BUSProcessor::processBuffer() {
       b.UMI = check_tag_sequence || bulk_like ? umi_binary : stringToBinary(umi, ulen, f);
       b.flags |= (f) << 8;
       b.count = 1;
-      //std::cout << std::string(s1,10)  << "\t" << b.barcode << "\t" << std::string(s1+10,16) << "\t" << b.UMI << "\n";
       if (num) {
         b.flags = (uint32_t) flags[i / jmax];
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ void ParseOptionsIndex(int argc, char **argv, ProgramOptions& opt) {
     if (opt.d_list_overhang < 3) {
         cerr << "[index] WARNING --d-list-overhang set to < 3; should be >= 3 with --aa" << endl;
         // cerr << "[index] --d-list-overhang set to 3 (with --aa, the d-list overhang must be >= 3)" << endl;
-        // opt.d_list_overhang = 3;
+        //opt.d_list_overhang = 3;
     }
   }
   if (distinguish_flag) {
@@ -648,8 +648,8 @@ void ParseOptionsBus(int argc, char **argv, ProgramOptions& opt) {
   // throw warning when --aa is passed with paired-end arg 
   // paired-end currently not supported in --aa mode -> will automatically switch to single-end
   if (aa_flag) {
-    opt.aa =true;
-    opt.dfk_onlist =true;
+    opt.aa = true;
+    opt.dfk_onlist = true;
     opt.single_end = true;
     if (paired_end_flag) {
       cerr << "[bus] --paired ignored; --aa only supports single-end reads" << endl;
@@ -2166,7 +2166,7 @@ int main(int argc, char *argv[]) {
       
       KmerIndex index(opt);
       index.load(opt);
-      
+
       bool guessChromosomes = true;
       Transcriptome model; // empty
       if (opt.genomebam) {
@@ -2381,10 +2381,6 @@ int main(int argc, char *argv[]) {
           collection.init_mean_fl_trunc( mean_fl, sd_fl );
           //fld.resize(MAX_FRAG_LEN,0); // no obersvations
           fld = trunc_gaussian_counts(0, MAX_FRAG_LEN, mean_fl, sd_fl, 10000);
-
-          // for (size_t i = 0; i < collection.mean_fl_trunc.size(); ++i) {
-          //   cout << "--- " << i << '\t' << collection.mean_fl_trunc[i] << endl;
-          // }
         }
 
         std::vector<int32_t> preBias(4096,1);
@@ -2393,10 +2389,6 @@ int main(int argc, char *argv[]) {
         }
 
         auto fl_means = get_frag_len_means(index.target_lens_, collection.mean_fl_trunc);
-
-        //for (int i = 0; i < collection.bias3.size(); i++) {
-          //std::cout << i << "\t" << collection.bias3[i] << "\t" << collection.bias5[i] << "\n";
-        //}
 
         EMAlgorithm em(collection.counts, index, collection, fl_means, opt);
         em.run(10000, 50, true, opt.bias);


### PR DESCRIPTION
This PR changes the transcript IDs of the D-list sequences in the de Bruijn graph, such that they all have the same ID. Otherwise, if a read aligns to more than one D-list sequence they will be masked out in the intersection.