### PR TITLE
fix build errors with `sz_link` and missing `hdf5`

### DIFF
--- a/ext/bifrost/src/DataStorage.tcc
+++ b/ext/bifrost/src/DataStorage.tcc
@@ -78,7 +78,7 @@ DataStorage<U>::DataStorage(const DataStorage& o) : color_sets(nullptr), shared_
 
         unitig_cs_link = new std::atomic<uint64_t>[sz_link];
 
-        for (size_t i = 0; i != sz_link; ++i) unitig_cs_link[i] = o.sz_link[i].load();
+        for (size_t i = 0; i != sz_link; ++i) unitig_cs_link[i] = o.unitig_cs_link[i].load();
     }
 
     if ((o.data != nullptr) && (o.sz_cs != 0)){

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ endif(LINK MATCHES static)
 
 
 if(USE_HDF5)
-    #find_package( HDF5 COMPONENTS CXX REQUIRED )
+    find_package( HDF5 COMPONENTS CXX REQUIRED )
 endif(USE_HDF5)
 
 if (NOT ZLIBNG)
@@ -74,13 +74,13 @@ if (ZLIBNG)
 endif(ZLIBNG)
 
 if(USE_HDF5)
-    #if(HDF5_FOUND)
+    if(HDF5_FOUND)
         include_directories( ${HDF5_INCLUDE_DIRS} )
-        #target_link_libraries( kallisto_core ${HDF5_LIBRARIES} )
+        target_link_libraries( kallisto_core ${HDF5_LIBRARIES} )
         target_link_libraries( kallisto ${HDF5_LIBRARIES} )
-    #else()
-    #    message(FATAL_ERROR "HDF5 not found. Required to output files")
-    #endif()
+    else()
+        message(FATAL_ERROR "HDF5 not found. Required to output files")
+    endif()
 endif(USE_HDF5)
 
 if(LINK MATCHES static)


### PR DESCRIPTION
1. 

```
cd /private/tmp/kallisto-20260228-18650-dy0tkb/kallisto-0.52.0/ext/bifrost/build/src && /opt/homebrew/Library/Homebrew/shims/mac/super/clang++ -DMAX_GMER_SIZE=32 -DMAX_KMER_SIZE=32 -I/private/tmp/kallisto-20260228-18650-dy0tkb/kallisto-0.52.0/ext/bifrost/src -Wno-subobject-linkage -Wno-return-type -std=c++11  -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -O3 -MD -MT src/CMakeFiles/bifrost_static.dir/Bifrost.cpp.o -MF CMakeFiles/bifrost_static.dir/Bifrost.cpp.o.d -o CMakeFiles/bifrost_static.dir/Bifrost.cpp.o -c /private/tmp/kallisto-20260228-18650-dy0tkb/kallisto-0.52.0/ext/bifrost/src/Bifrost.cpp
In file included from /private/tmp/kallisto-20260228-18650-dy0tkb/kallisto-0.52.0/ext/bifrost/src/Bifrost.cpp:2:
In file included from /private/tmp/kallisto-20260228-18650-dy0tkb/kallisto-0.52.0/ext/bifrost/src/ColoredCDBG.hpp:10:
In file included from /private/tmp/kallisto-20260228-18650-dy0tkb/kallisto-0.52.0/ext/bifrost/src/DataManager.hpp:10:
/private/tmp/kallisto-20260228-18650-dy0tkb/kallisto-0.52.0/ext/bifrost/src/DataStorage.tcc:81:69: error: no member named 'sz_link' in 'DataStorage<Unitig_data_t>'
   81 |         for (size_t i = 0; i != sz_link; ++i) unitig_cs_link[i] = o.sz_link[i].load();
      |                                                                   ~ ^
1 error generated.
make[5]: *** [src/CMakeFiles/bifrost_static.dir/Bifrost.cpp.o] Error 1
```

- https://github.com/pmelsted/bifrost/pull/18

2. 

- https://github.com/pachterlab/kallisto/issues/505